### PR TITLE
Fix missing id field in GraphQL queries for User-typed fields

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -45,7 +45,10 @@ impl LinearClient {
             return Err(LinError::ApiError(format!("HTTP {status}: {text}")));
         }
 
-        let gql_response: GraphQLResponse<T> = response.json().await?;
+        let text = response.text().await?;
+        let gql_response: GraphQLResponse<T> = serde_json::from_str(&text).map_err(|e| {
+            LinError::ApiError(format!("Failed to decode response: {e}"))
+        })?;
 
         if let Some(errors) = gql_response.errors {
             let messages: Vec<String> = errors.into_iter().map(|e| e.message).collect();

--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -120,7 +120,7 @@ pub const COMMENTS_QUERY: &str = r#"
                 nodes {
                     id
                     body
-                    user { name }
+                    user { id name }
                     createdAt
                     updatedAt
                 }
@@ -162,7 +162,7 @@ pub const PROJECTS_QUERY: &str = r#"
                 id
                 name
                 state
-                lead { name }
+                lead { id name }
                 startDate
                 targetDate
             }
@@ -177,7 +177,7 @@ pub const PROJECT_QUERY: &str = r#"
             name
             description
             state
-            lead { name }
+            lead { id name }
             members { nodes { name } }
             startDate
             targetDate
@@ -222,7 +222,7 @@ pub const PROJECT_UPDATES_QUERY: &str = r#"
                     body
                     health
                     createdAt
-                    user { name }
+                    user { id name }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Added missing `id` field to 4 GraphQL queries where `User`-typed fields (`lead`, `user`) were fetched without it, causing deserialization failures
- Improved error handling in API client to show actual serde error messages instead of opaque "error decoding response body"

Closes #2

## Test plan
- [x] `lin --workspace plotzy project list` now works
- [x] `lin --workspace plotzy issue create --team plotzy --project "March 2026" "Test issue"` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)