### PR TITLE
Fix file upload by including signed headers from presigned URL

### DIFF
--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -326,6 +326,10 @@ pub const FILE_UPLOAD_MUTATION: &str = r#"
             uploadFile {
                 uploadUrl
                 assetUrl
+                headers {
+                    key
+                    value
+                }
             }
         }
     }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -413,6 +413,14 @@ pub struct FileUploadPayload {
 pub struct UploadFile {
     pub upload_url: String,
     pub asset_url: String,
+    #[serde(default)]
+    pub headers: Vec<UploadHeader>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UploadHeader {
+    pub key: String,
+    pub value: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api/upload.rs
+++ b/src/api/upload.rs
@@ -58,15 +58,18 @@ pub async fn upload_file(client: &LinearClient, file_path: &str) -> Result<Strin
     let upload_url = &data.file_upload.upload_file.upload_url;
     let asset_url = data.file_upload.upload_file.asset_url.clone();
 
-    // Step 2: PUT file bytes to the presigned URL
+    // Step 2: PUT file bytes to the presigned URL with required signed headers
     let http_client = reqwest::Client::new();
-    let response = http_client
+    let mut request = http_client
         .put(upload_url)
         .header("Content-Type", content_type)
-        .header("Cache-Control", "public, max-age=31536000")
-        .body(file_bytes)
-        .send()
-        .await?;
+        .header("Cache-Control", "public, max-age=31536000");
+
+    for header in &data.file_upload.upload_file.headers {
+        request = request.header(&header.key, &header.value);
+    }
+
+    let response = request.body(file_bytes).send().await?;
 
     if !response.status().is_success() {
         let status = response.status();


### PR DESCRIPTION
## Summary

Fixes #6 — File uploads via `--attachment` fail with a `400 Bad Request` because the PUT request to the GCS presigned URL is missing required signed headers (e.g. `x-goog-content-length-range`).

### Changes

- **`src/api/queries.rs`** — Request `headers { key value }` from the `uploadFile` response
- **`src/api/types.rs`** — Add `UploadHeader` struct and `headers` field to `UploadFile`
- **`src/api/upload.rs`** — Forward returned headers in the PUT request to GCS

## Test plan

- [ ] Run `lin issue create --team <TEAM> --attachment path/to/image.png "Test"` and verify upload succeeds
- [ ] Verify `cargo check` passes