### PR TITLE
Fix issue edit --state resolution

### DIFF
--- a/src/api/resolve.rs
+++ b/src/api/resolve.rs
@@ -116,6 +116,56 @@ pub async fn resolve_project_identifier(client: &LinearClient, identifier: &str)
     }
 }
 
+/// Resolve a workflow state name to a UUID for a given issue.
+/// Fetches the issue's team, then matches the state name case-insensitively.
+pub async fn resolve_state_name(
+    client: &LinearClient,
+    issue_id: &str,
+    state_name: &str,
+) -> Result<String> {
+    if is_uuid(state_name) {
+        return Ok(state_name.to_string());
+    }
+
+    let issue_data: IssueData = client
+        .execute(ISSUE_QUERY, Some(json!({ "id": issue_id })))
+        .await?;
+    let team = issue_data
+        .issue
+        .team
+        .ok_or_else(|| anyhow::anyhow!("Issue has no team"))?;
+
+    let team_data: TeamData = client
+        .execute(TEAM_STATES_QUERY, Some(json!({ "id": team.id })))
+        .await?;
+
+    let target_lower = state_name.to_lowercase();
+    let matching = team_data
+        .team
+        .states
+        .nodes
+        .iter()
+        .find(|s| s.name.to_lowercase() == target_lower);
+
+    match matching {
+        Some(state) => Ok(state.id.clone()),
+        None => {
+            let available: Vec<&str> = team_data
+                .team
+                .states
+                .nodes
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect();
+            bail!(
+                "State '{}' not found. Available states: {}",
+                state_name,
+                available.join(", ")
+            )
+        }
+    }
+}
+
 /// Resolve label names to label IDs via case-insensitive matching.
 pub async fn resolve_label_names(client: &LinearClient, names: &[String]) -> Result<Vec<String>> {
     let data: LabelsData = client.execute(LABELS_QUERY, None).await?;

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -251,6 +251,11 @@ pub async fn edit(
         None => None,
     };
 
+    let resolved_state = match state {
+        Some(ref s) => Some(resolve::resolve_state_name(client, id, s).await?),
+        None => None,
+    };
+
     let resolved_project = match project {
         Some(ref p) => Some(resolve::resolve_project_identifier(client, p).await?),
         None => None,
@@ -261,7 +266,7 @@ pub async fn edit(
         description,
         priority,
         assignee_id: resolved_assignee,
-        state_id: state,
+        state_id: resolved_state,
         project_id: resolved_project,
         label_ids: final_label_ids,
         parent_id: resolved_parent,


### PR DESCRIPTION
## Summary

- Fixes #11 — `lin issue edit --state "Todo"` was passing the state name directly as `state_id`, causing a GraphQL argument validation error
- Added `resolve_state_name` in `resolve.rs` that fetches the issue's team workflow states and matches by name (case-insensitive), consistent with `lin issue state` behavior
- UUIDs passed as `--state` are still accepted as-is

## Test plan

- [ ] `lin issue edit <id> --state "Todo"` no longer errors
- [ ] `lin issue edit <id> --state "In Progress"` works with multi-word states
- [ ] `lin issue edit <id> --state "nonexistent"` shows available states in error message
- [ ] `cargo test` passes