### PR TITLE
Add issue attachments add subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -621,7 +621,14 @@ mod tests {
 
     #[test]
     fn issue_attachments_add_parses() {
-        let cli = parse(&["lin", "issue", "attachments", "add", "ENG-10", "screenshot.png"]);
+        let cli = parse(&[
+            "lin",
+            "issue",
+            "attachments",
+            "add",
+            "ENG-10",
+            "screenshot.png",
+        ]);
         match cli.command {
             Commands::Issue(IssueCommand::Attachments(AttachmentCommand::Add {
                 id,
@@ -649,7 +656,9 @@ mod tests {
             "My Screenshot",
         ]);
         match cli.command {
-            Commands::Issue(IssueCommand::Attachments(AttachmentCommand::Add { title, .. })) => {
+            Commands::Issue(IssueCommand::Attachments(AttachmentCommand::Add {
+                title, ..
+            })) => {
                 assert_eq!(title.as_deref(), Some("My Screenshot"));
             }
             _ => panic!("expected Issue Attachments Add"),

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -638,9 +638,6 @@ pub async fn attachment_add(
     file_path: &str,
     title: Option<&str>,
 ) -> Result<()> {
-    if !std::path::Path::new(file_path).exists() {
-        bail!("File not found: {}", file_path);
-    }
     let issue_id = resolve::resolve_issue_identifier(client, id).await?;
     let asset_url = upload::upload_file(client, file_path).await?;
     let filename = std::path::Path::new(file_path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,13 +196,8 @@ async fn run(cli: Cli) -> Result<()> {
                         commands::issue::attachments(&ctx.client, &id).await?;
                     }
                     AttachmentCommand::Add { id, file, title } => {
-                        commands::issue::attachment_add(
-                            &ctx.client,
-                            &id,
-                            &file,
-                            title.as_deref(),
-                        )
-                        .await?;
+                        commands::issue::attachment_add(&ctx.client, &id, &file, title.as_deref())
+                            .await?;
                     }
                 },
                 IssueCommand::Comment {


### PR DESCRIPTION
## Summary

- Converts `issue attachments` from a flat command to a subcommand group with `list` and `add`
- New `add` command uploads a file and creates an attachment on the specified issue
- Supports optional `--title` flag (defaults to filename)
- Adds 3 CLI parsing tests for the new subcommand

Closes #13

## Breaking Change

`lin issue attachments <id>` is now `lin issue attachments list <id>`.

## Test plan

- [x] All 8 CLI parsing tests pass (`cargo test`)
- [ ] Manual test: `lin issue attachments list ENG-123`
- [ ] Manual test: `lin issue attachments add ENG-123 ./file.png`
- [ ] Manual test: `lin issue attachments add ENG-123 ./file.png --title "Custom"`