### PR TITLE
feat(lin-1): Add date filters to lin issue list

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,6 +211,38 @@ pub enum IssueCommand {
         #[arg(long)]
         priority: Option<i32>,
 
+        /// Filter issues updated on or after date (ISO 8601: 2026-03-24 or relative: 3d, 1w, 2h)
+        #[arg(long)]
+        updated_since: Option<String>,
+
+        /// Filter issues updated before date (ISO 8601: 2026-03-24 or relative: 3d, 1w, 2h)
+        #[arg(long)]
+        updated_before: Option<String>,
+
+        /// Filter issues created on or after date (ISO 8601: 2026-03-24 or relative: 3d, 1w, 2h)
+        #[arg(long)]
+        created_since: Option<String>,
+
+        /// Filter issues created before date (ISO 8601: 2026-03-24 or relative: 3d, 1w, 2h)
+        #[arg(long)]
+        created_before: Option<String>,
+
+        /// Filter issues completed on or after date (ISO 8601: 2026-03-24 or relative: 3d, 1w, 2h)
+        #[arg(long)]
+        completed_since: Option<String>,
+
+        /// Filter issues completed before date (ISO 8601: 2026-03-24 or relative: 3d, 1w, 2h)
+        #[arg(long)]
+        completed_before: Option<String>,
+
+        /// Filter issues due after date (ISO 8601: 2026-03-24 or relative: 3d, 1w, 2h)
+        #[arg(long)]
+        due_after: Option<String>,
+
+        /// Filter issues due before date (ISO 8601: 2026-03-24 or relative: 3d, 1w, 2h)
+        #[arg(long)]
+        due_before: Option<String>,
+
         /// Max results
         #[arg(long, default_value = "20")]
         limit: i32,
@@ -568,6 +600,90 @@ mod tests {
                 assert_eq!(body, "top level comment");
             }
             _ => panic!("expected Comment Add"),
+        }
+    }
+
+    #[test]
+    fn issue_list_with_date_filters() {
+        let cli = parse(&[
+            "lin",
+            "issue",
+            "list",
+            "--updated-since",
+            "3d",
+            "--updated-before",
+            "2026-03-24",
+        ]);
+        match cli.command {
+            Commands::Issue(IssueCommand::List {
+                updated_since,
+                updated_before,
+                ..
+            }) => {
+                assert_eq!(updated_since.as_deref(), Some("3d"));
+                assert_eq!(updated_before.as_deref(), Some("2026-03-24"));
+            }
+            _ => panic!("expected Issue List"),
+        }
+    }
+
+    #[test]
+    fn issue_list_with_all_date_filters() {
+        let cli = parse(&[
+            "lin",
+            "issue",
+            "list",
+            "--updated-since",
+            "1w",
+            "--created-since",
+            "2w",
+            "--completed-since",
+            "2026-01-01",
+            "--due-before",
+            "2026-12-31",
+        ]);
+        match cli.command {
+            Commands::Issue(IssueCommand::List {
+                updated_since,
+                created_since,
+                completed_since,
+                due_before,
+                ..
+            }) => {
+                assert_eq!(updated_since.as_deref(), Some("1w"));
+                assert_eq!(created_since.as_deref(), Some("2w"));
+                assert_eq!(completed_since.as_deref(), Some("2026-01-01"));
+                assert_eq!(due_before.as_deref(), Some("2026-12-31"));
+            }
+            _ => panic!("expected Issue List"),
+        }
+    }
+
+    #[test]
+    fn issue_list_combines_with_existing_filters() {
+        let cli = parse(&[
+            "lin",
+            "issue",
+            "list",
+            "--team",
+            "engineering",
+            "--status",
+            "In Progress",
+            "--updated-since",
+            "3d",
+        ]);
+        match cli.command {
+            Commands::Issue(IssueCommand::List {
+                team,
+                status,
+                updated_since,
+                ..
+            }) => {
+                assert_eq!(team.as_deref(), Some("engineering"));
+                assert_eq!(status.as_deref(), Some("In Progress"));
+                assert_eq!(updated_since.as_deref(), Some("3d"));
+            }
+            _ => panic!("expected Issue List"),
         }
     }
 }

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -6,7 +6,21 @@ use crate::api::queries::*;
 use crate::api::resolve;
 use crate::api::types::*;
 use crate::api::upload;
+use crate::date;
 use crate::output;
+
+/// Date filter options for issue listing
+#[derive(Default)]
+pub struct DateFilters {
+    pub updated_since: Option<String>,
+    pub updated_before: Option<String>,
+    pub created_since: Option<String>,
+    pub created_before: Option<String>,
+    pub completed_since: Option<String>,
+    pub completed_before: Option<String>,
+    pub due_after: Option<String>,
+    pub due_before: Option<String>,
+}
 
 pub async fn view(client: &LinearClient, id: &str) -> Result<()> {
     let data: IssueData = client
@@ -321,6 +335,7 @@ pub async fn search(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn list(
     client: &LinearClient,
     team: Option<&str>,
@@ -328,6 +343,7 @@ pub async fn list(
     status: Option<&str>,
     project: Option<&str>,
     priority: Option<i32>,
+    date_filters: DateFilters,
     limit: i32,
 ) -> Result<()> {
     let mut filter = json!({});
@@ -350,6 +366,32 @@ pub async fn list(
         filter["priority"] = json!({ "eq": p });
     }
 
+    // Apply date filters
+    apply_date_filter(
+        &mut filter,
+        "updatedAt",
+        date_filters.updated_since.as_deref(),
+        date_filters.updated_before.as_deref(),
+    )?;
+    apply_date_filter(
+        &mut filter,
+        "createdAt",
+        date_filters.created_since.as_deref(),
+        date_filters.created_before.as_deref(),
+    )?;
+    apply_date_filter(
+        &mut filter,
+        "completedAt",
+        date_filters.completed_since.as_deref(),
+        date_filters.completed_before.as_deref(),
+    )?;
+    apply_date_filter(
+        &mut filter,
+        "dueDate",
+        date_filters.due_after.as_deref(),
+        date_filters.due_before.as_deref(),
+    )?;
+
     let variables = json!({
         "first": limit,
         "filter": filter,
@@ -359,6 +401,36 @@ pub async fn list(
     let issues = data.issues.nodes;
 
     print_issues_table(&issues);
+    Ok(())
+}
+
+/// Applies a date filter to the filter object.
+/// For updatedAt/createdAt/completedAt: uses "gte" for since and "lt" for before
+/// For dueDate: uses "gt" for after and "lt" for before
+fn apply_date_filter(
+    filter: &mut serde_json::Value,
+    field: &str,
+    since_or_after: Option<&str>,
+    before: Option<&str>,
+) -> Result<()> {
+    let since_key = if field == "dueDate" { "gt" } else { "gte" };
+
+    let since_parsed = since_or_after.map(date::parse_date).transpose()?;
+    let before_parsed = before.map(date::parse_date).transpose()?;
+
+    match (since_parsed, before_parsed) {
+        (Some(s), Some(b)) => {
+            filter[field] = json!({ since_key: s, "lt": b });
+        }
+        (Some(s), None) => {
+            filter[field] = json!({ since_key: s });
+        }
+        (None, Some(b)) => {
+            filter[field] = json!({ "lt": b });
+        }
+        (None, None) => {}
+    }
+
     Ok(())
 }
 

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,0 +1,157 @@
+use anyhow::{Result, bail};
+use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
+
+/// Parses a date string into an ISO 8601 formatted string for the Linear API.
+///
+/// Accepts:
+/// - ISO 8601 dates: `2026-03-24`, `2026-03-24T10:00:00Z`
+/// - Relative shorthand: `3d` (3 days ago), `1w` (1 week ago), `2h` (2 hours ago)
+pub fn parse_date(input: &str) -> Result<String> {
+    let input = input.trim();
+
+    // Try relative shorthand first (e.g., 3d, 1w, 2h)
+    if let Some(duration) = parse_relative(input) {
+        let now = OffsetDateTime::now_utc();
+        let target = now - duration;
+        return Ok(target.format(&Rfc3339)?);
+    }
+
+    // Try ISO 8601 date-only format (YYYY-MM-DD)
+    if input.len() == 10 && input.chars().nth(4) == Some('-') && input.chars().nth(7) == Some('-') {
+        // Validate by parsing
+        let parts: Vec<&str> = input.split('-').collect();
+        if parts.len() == 3 {
+            let year: i32 = parts[0]
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Invalid year"))?;
+            let month: u8 = parts[1]
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Invalid month"))?;
+            let day: u8 = parts[2]
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Invalid day"))?;
+
+            if !(1..=12).contains(&month) {
+                bail!("Invalid month: {}", month);
+            }
+            if !(1..=31).contains(&day) {
+                bail!("Invalid day: {}", day);
+            }
+
+            // Return as ISO 8601 with midnight UTC
+            return Ok(format!("{:04}-{:02}-{:02}T00:00:00Z", year, month, day));
+        }
+    }
+
+    // Try full ISO 8601 datetime (already valid for Linear API)
+    if input.contains('T') {
+        // Validate by attempting to parse as RFC 3339
+        match OffsetDateTime::parse(input, &Rfc3339) {
+            Ok(dt) => return Ok(dt.format(&Rfc3339)?),
+            Err(_) => {
+                // Try adding Z if missing timezone
+                let with_z =
+                    if !input.ends_with('Z') && !input.contains('+') && !input.contains('-') {
+                        format!("{}Z", input)
+                    } else {
+                        input.to_string()
+                    };
+                if let Ok(dt) = OffsetDateTime::parse(&with_z, &Rfc3339) {
+                    return Ok(dt.format(&Rfc3339)?);
+                }
+            }
+        }
+    }
+
+    bail!(
+        "Invalid date format: '{}'. Expected ISO 8601 (e.g., 2026-03-24) or relative (e.g., 3d, 1w, 2h)",
+        input
+    )
+}
+
+/// Parses relative time shorthand like "3d", "1w", "2h" into a Duration.
+fn parse_relative(input: &str) -> Option<Duration> {
+    let input = input.trim();
+    if input.is_empty() {
+        return None;
+    }
+
+    let (num_str, unit) = input.split_at(input.len() - 1);
+    let num: i64 = num_str.parse().ok()?;
+
+    if num <= 0 {
+        return None;
+    }
+
+    match unit {
+        "h" => Some(Duration::hours(num)),
+        "d" => Some(Duration::days(num)),
+        "w" => Some(Duration::weeks(num)),
+        "m" => Some(Duration::days(num * 30)), // Approximate month
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_iso_date() {
+        let result = parse_date("2026-03-24").unwrap();
+        assert_eq!(result, "2026-03-24T00:00:00Z");
+    }
+
+    #[test]
+    fn parse_iso_datetime() {
+        let result = parse_date("2026-03-24T10:30:00Z").unwrap();
+        assert!(result.contains("2026-03-24"));
+        assert!(result.contains("10:30:00"));
+    }
+
+    #[test]
+    fn parse_relative_days() {
+        let result = parse_date("3d").unwrap();
+        // Should be a valid RFC3339 timestamp
+        assert!(result.contains("T"));
+        assert!(result.ends_with("Z"));
+    }
+
+    #[test]
+    fn parse_relative_weeks() {
+        let result = parse_date("1w").unwrap();
+        assert!(result.contains("T"));
+        assert!(result.ends_with("Z"));
+    }
+
+    #[test]
+    fn parse_relative_hours() {
+        let result = parse_date("2h").unwrap();
+        assert!(result.contains("T"));
+        assert!(result.ends_with("Z"));
+    }
+
+    #[test]
+    fn invalid_date_errors() {
+        assert!(parse_date("invalid").is_err());
+        assert!(parse_date("2026-13-01").is_err()); // Invalid month
+        assert!(parse_date("2026-01-32").is_err()); // Invalid day
+    }
+
+    #[test]
+    fn parse_relative_months() {
+        let result = parse_date("2m").unwrap();
+        assert!(result.contains("T"));
+        assert!(result.ends_with("Z"));
+    }
+
+    #[test]
+    fn zero_relative_fails() {
+        assert!(parse_date("0d").is_err());
+    }
+
+    #[test]
+    fn negative_relative_fails() {
+        assert!(parse_date("-3d").is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod auth;
 mod cli;
 mod commands;
 mod config;
+mod date;
 mod error;
 mod output;
 mod workspace;
@@ -152,8 +153,26 @@ async fn run(cli: Cli) -> Result<()> {
                     status,
                     project,
                     priority,
+                    updated_since,
+                    updated_before,
+                    created_since,
+                    created_before,
+                    completed_since,
+                    completed_before,
+                    due_after,
+                    due_before,
                     limit,
                 } => {
+                    let date_filters = commands::issue::DateFilters {
+                        updated_since,
+                        updated_before,
+                        created_since,
+                        created_before,
+                        completed_since,
+                        completed_before,
+                        due_after,
+                        due_before,
+                    };
                     commands::issue::list(
                         &ctx.client,
                         team.as_deref(),
@@ -161,6 +180,7 @@ async fn run(cli: Cli) -> Result<()> {
                         status.as_deref(),
                         project.as_deref(),
                         priority,
+                        date_filters,
                         limit,
                     )
                     .await?;


### PR DESCRIPTION
## Summary
- Add 8 date-based filtering flags to `lin issue list`:
  - `--updated-since` / `--updated-before` (updatedAt field)
  - `--created-since` / `--created-before` (createdAt field)
  - `--completed-since` / `--completed-before` (completedAt field)
  - `--due-after` / `--due-before` (dueDate field)
- Support ISO 8601 dates (`2026-03-24`, `2026-03-24T10:00:00Z`) and relative shorthand (`3d`, `1w`, `2h`)
- Add date parsing utility module with comprehensive tests

## Test plan
- [x] All 8 date flags are available on `lin issue list --help`
- [x] ISO 8601 date strings are validated and passed to Linear API
- [x] Relative shorthand (3d, 1w, 2h) is parsed correctly
- [x] Flags compose with existing filters (team, status, etc.)
- [x] Combined range works (e.g., `--updated-since 2026-03-20 --updated-before 2026-03-24`)
- [x] Invalid date input produces clear error messages
- [x] All 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)