### PR TITLE
feat: Add cycle support to issue create and edit

### DIFF
--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -28,6 +28,7 @@ pub const ISSUE_QUERY: &str = r#"
             labels { nodes { id name color } }
             children { nodes { identifier title } }
             parent { identifier title }
+            cycle { id number name }
         }
     }
 "#;

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -92,6 +92,15 @@ pub struct Issue {
     pub labels: Option<Connection<Label>>,
     pub children: Option<Connection<ChildIssue>>,
     pub parent: Option<ParentIssue>,
+    pub cycle: Option<CycleRef>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CycleRef {
+    pub id: String,
+    pub number: Option<i32>,
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -182,6 +191,8 @@ pub struct IssueCreateInput {
     pub label_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cycle_id: Option<String>,
 }
 
 // --- Comment ---
@@ -482,6 +493,8 @@ pub struct IssueUpdateInput {
     pub label_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cycle_id: Option<String>,
 }
 
 // --- Cycles ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,10 @@ pub enum IssueCommand {
         #[arg(long)]
         parent: Option<String>,
 
+        /// Cycle (name, number, or "current" for active cycle)
+        #[arg(long)]
+        cycle: Option<String>,
+
         /// Attach a file to the created issue
         #[arg(long)]
         attachment: Option<String>,
@@ -161,6 +165,10 @@ pub enum IssueCommand {
         /// Parent issue ID or identifier (e.g., APP-123)
         #[arg(long)]
         parent: Option<String>,
+
+        /// Cycle (name, number, or "current" for active cycle)
+        #[arg(long)]
+        cycle: Option<String>,
 
         /// Attach a file to the issue
         #[arg(long)]

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -65,6 +65,15 @@ pub async fn view(client: &LinearClient, id: &str, json: bool) -> Result<()> {
     if let Some(ref project) = issue.project {
         output::print_field("Project", &project.name);
     }
+    if let Some(ref cycle) = issue.cycle {
+        let display = match (&cycle.name, cycle.number) {
+            (Some(name), Some(num)) => format!("{} (#{})", name, num),
+            (Some(name), None) => name.clone(),
+            (None, Some(num)) => format!("#{}", num),
+            (None, None) => "—".to_string(),
+        };
+        output::print_field("Cycle", &display);
+    }
     if let Some(priority) = issue.priority {
         let label = match priority as i32 {
             0 => "None",
@@ -138,13 +147,14 @@ pub async fn create(
     label_ids: Option<&[String]>,
     labels: Option<&[String]>,
     parent: Option<&str>,
+    cycle: Option<&str>,
     attachment_path: Option<&str>,
 ) -> Result<()> {
     let team_id = resolve::resolve_team_identifier(client, team).await?;
 
     let mut input = IssueCreateInput {
         title: title.to_string(),
-        team_id,
+        team_id: team_id.clone(),
         ..Default::default()
     };
     input.description = description.map(|s| s.to_string());
@@ -172,6 +182,12 @@ pub async fn create(
     if let Some(pid) = parent {
         let resolved = resolve::resolve_issue_identifier(client, pid).await?;
         input.parent_id = Some(resolved);
+    }
+
+    // Resolve cycle
+    if let Some(cyc) = cycle {
+        let resolved = resolve::resolve_cycle_identifier(client, &input.team_id, cyc).await?;
+        input.cycle_id = Some(resolved);
     }
 
     let data: IssueCreateData = client
@@ -217,6 +233,7 @@ pub async fn edit(
     labels: Option<Vec<String>>,
     remove_labels: Option<Vec<String>>,
     parent: Option<String>,
+    cycle: Option<String>,
     attachment_path: Option<String>,
 ) -> Result<()> {
     // Resolve label names
@@ -283,6 +300,20 @@ pub async fn edit(
         None => None,
     };
 
+    // Resolve cycle (fetch issue's team if needed)
+    let resolved_cycle = if let Some(ref cyc) = cycle {
+        let issue_data: IssueData = client
+            .execute(ISSUE_QUERY, Some(json!({ "id": id })))
+            .await?;
+        let team = issue_data
+            .issue
+            .team
+            .ok_or_else(|| anyhow::anyhow!("Issue has no team"))?;
+        Some(resolve::resolve_cycle_identifier(client, &team.id, cyc).await?)
+    } else {
+        None
+    };
+
     let input = IssueUpdateInput {
         title,
         description,
@@ -292,6 +323,7 @@ pub async fn edit(
         project_id: resolved_project,
         label_ids: final_label_ids,
         parent_id: resolved_parent,
+        cycle_id: resolved_cycle,
     };
 
     let data: IssueUpdateData = client

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ async fn run(cli: Cli) -> Result<()> {
                     label_ids,
                     labels,
                     parent,
+                    cycle,
                     attachment,
                 } => {
                     commands::issue::create(
@@ -93,6 +94,7 @@ async fn run(cli: Cli) -> Result<()> {
                         label_ids.as_deref(),
                         labels.as_deref(),
                         parent.as_deref(),
+                        cycle.as_deref(),
                         attachment.as_deref(),
                     )
                     .await?;
@@ -109,6 +111,7 @@ async fn run(cli: Cli) -> Result<()> {
                     labels,
                     remove_labels,
                     parent,
+                    cycle,
                     attachment,
                     comment,
                 } => {
@@ -125,6 +128,7 @@ async fn run(cli: Cli) -> Result<()> {
                         labels,
                         remove_labels,
                         parent,
+                        cycle,
                         attachment,
                     )
                     .await?;


### PR DESCRIPTION
Closes #23

## Summary
- Add `--cycle` flag to `issue create` and `issue edit` commands for assigning issues to cycles (accepts name, number, or "current" for the active cycle)
- Display cycle info (name and number) in `issue view` output
- For `issue edit`, auto-detects the issue's team so `--team` isn't required

## Usage
```sh
lin issue create "Fix auth" --team eng --cycle current
lin issue create "Sprint task" --team eng --cycle 42
lin issue edit ENG-123 --cycle "March Sprint"
```

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all 41 tests pass
- [ ] Manual: `lin issue create "test" --team <team> --cycle current` assigns to active cycle
- [ ] Manual: `lin issue edit <id> --cycle <number>` moves issue to cycle
- [ ] Manual: `lin issue view <id>` shows cycle field
- [ ] Manual: `lin issue create` without `--cycle` still works as before