### PR TITLE
docs: Update README for v0.6.0 features

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,4 @@
 - [ ] `cargo test` passes
 - [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
 - [ ] Manually tested with `lin ...`
+- [ ] README updated (if user-facing changes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Token storage now defaults to file-based (`~/.linear-cli/tokens.json`) instead of OS keychain, eliminating repeated password prompts on macOS. Use `lin login --keyring` to opt into keychain storage. Existing keychain tokens are read as a fallback.
+- Updated README with v0.6.0 features: cycle create/show, --cycle flag, --json, -v/--verbose, LINEAR_API_TOKEN env var, --keyring, project --content
 
 ## [0.6.0] - 2026-04-01
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ lin issue edit ENG-123 --cycle 42
 lin issue state ENG-123
 lin issue state ENG-123 "Done"
 lin issue state ENG-123 --list
-lin issue attachments ENG-123
+lin issue attachments list ENG-123
+lin issue attachments add ENG-123 screenshot.png
+lin issue attachments download ENG-123 -o /tmp/
+lin issue attachments download ENG-123 --attachment-id f17b -o /tmp/
 ```
 
 ### Comments

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ To associate the token with a named workspace:
 lin login <your-api-key> --name my-workspace
 ```
 
+Tokens are stored in `~/.linear-cli/tokens.json` by default. To use the OS keychain instead:
+
+```sh
+lin login <your-api-key> --keyring
+```
+
+You can also provide a token via the `LINEAR_API_TOKEN` environment variable:
+
+```sh
+LINEAR_API_TOKEN=<token> lin issue list --team APP
+```
+
 ## Usage
 
 ### Issues
@@ -54,7 +66,9 @@ lin issue me
 lin issue me --status "Todo"
 lin issue create "Fix login" --team APP
 lin issue create "Fix login" --team APP --assignee me --priority 2
+lin issue create "Sprint task" --team APP --cycle current
 lin issue edit ENG-123 --state "In Progress"
+lin issue edit ENG-123 --cycle 42
 lin issue state ENG-123
 lin issue state ENG-123 "Done"
 lin issue state ENG-123 --list
@@ -74,6 +88,7 @@ lin comment edit <comment-id> "Updated comment"
 ```sh
 lin project list
 lin project view "My Project"
+lin project view "My Project" --content
 lin project create "My Project" --teams APP
 lin project edit "My Project" --state started
 lin project update list "My Project"
@@ -85,6 +100,10 @@ lin project update add "My Project" "Sprint update" --health onTrack
 ```sh
 lin cycle list --team APP
 lin cycle active --team APP
+lin cycle show current --team APP
+lin cycle show 42 --team APP
+lin cycle create --team APP --starts 2026-04-07 --duration 1w --name "Sprint 1"
+lin cycle create --team APP --starts 2026-04-07 --ends 2026-04-14
 ```
 
 ### Initiatives
@@ -122,12 +141,6 @@ lin workspace list
 lin workspace set my-workspace
 ```
 
-Use the `-w` flag to target a specific workspace:
-
-```sh
-lin -w my-workspace issue view ENG-123
-```
-
 ### Identifier Resolution
 
 Most flags accept human-readable names instead of UUIDs:
@@ -135,7 +148,16 @@ Most flags accept human-readable names instead of UUIDs:
 - `--team` accepts a team name (e.g., `Engineering`), key (e.g., `APP`), or UUID
 - `--assignee` accepts a user name, email, `me`, or UUID
 - `--project` accepts a project name or UUID
+- `--cycle` accepts a cycle name, number, or `current`
 - Issue identifiers like `ENG-123` are resolved automatically
+
+### Global Flags
+
+```sh
+lin --json issue list --team APP    # Raw JSON output
+lin -v issue list --team APP        # Verbose error output (shows response body on failures)
+lin -w my-workspace issue list      # Target a specific workspace
+```
 
 Run `lin --help` for the full command reference.
 


### PR DESCRIPTION
## Summary

- Add cycle create/show examples and --cycle flag on issue create/edit
- Document --json and -v/--verbose global flags
- Document LINEAR_API_TOKEN env var and --keyring login option
- Document project --content flag
- Consolidate workspace -w flag into new Global Flags section

🤖 Generated with [Claude Code](https://claude.com/claude-code)