### PR TITLE
feat: Add top-level download command for Linear upload URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `cycle edit` command with `--name`, `--description`, `--starts`, and `--ends` flags for updating cycle properties
+- `lin download <URL>` command to download files directly from `uploads.linear.app` URLs without needing the parent issue
 
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,16 @@ pub enum Commands {
     #[command(subcommand)]
     Initiative(InitiativeCommand),
 
+    /// Download a file from a Linear upload URL
+    Download {
+        /// Linear upload URL (https://uploads.linear.app/...)
+        url: String,
+
+        /// Output directory (defaults to current directory)
+        #[arg(long, short, default_value = ".")]
+        output: String,
+    },
+
     /// View changelog
     Changelog,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1410,4 +1410,34 @@ mod tests {
             _ => panic!("expected Issue Edit"),
         }
     }
+
+    #[test]
+    fn download_parses() {
+        let cli = parse(&["lin", "download", "https://uploads.linear.app/abc/def/ghi"]);
+        match cli.command {
+            Commands::Download { url, output } => {
+                assert_eq!(url, "https://uploads.linear.app/abc/def/ghi");
+                assert_eq!(output, ".");
+            }
+            _ => panic!("expected Download"),
+        }
+    }
+
+    #[test]
+    fn download_with_output() {
+        let cli = parse(&[
+            "lin",
+            "download",
+            "https://uploads.linear.app/abc/def/ghi",
+            "-o",
+            "/tmp/downloads",
+        ]);
+        match cli.command {
+            Commands::Download { url, output } => {
+                assert_eq!(url, "https://uploads.linear.app/abc/def/ghi");
+                assert_eq!(output, "/tmp/downloads");
+            }
+            _ => panic!("expected Download"),
+        }
+    }
 }

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -58,5 +58,17 @@ mod tests {
         let result =
             run("fake-token", "https://evil.com?ref=uploads.linear.app", ".").await;
         assert!(result.is_err());
+
+        // Path spoofing
+        let result =
+            run("fake-token", "https://evil.com/uploads.linear.app", ".").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_url() {
+        let result = run("fake-token", "not-a-url", ".").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("invalid URL"));
     }
 }

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -1,10 +1,11 @@
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 
 use super::issue::{download_file, format_byte_size};
 use crate::output;
 
 pub async fn run(token: &str, url: &str, output: &str) -> Result<()> {
-    if !url.contains("uploads.linear.app") {
+    let parsed = reqwest::Url::parse(url).context("invalid URL")?;
+    if parsed.host_str() != Some("uploads.linear.app") {
         bail!("URL must be an uploads.linear.app link");
     }
 
@@ -12,6 +13,7 @@ pub async fn run(token: &str, url: &str, output: &str) -> Result<()> {
     std::fs::create_dir_all(output_dir)?;
 
     let client = reqwest::Client::new();
+    // download_file expects a dedup list for batch downloads; empty vec for single-file case
     let mut used: Vec<String> = Vec::new();
 
     match download_file(&client, url, token, output_dir, &mut used).await {
@@ -44,5 +46,17 @@ mod tests {
                 .to_string()
                 .contains("uploads.linear.app")
         );
+    }
+
+    #[tokio::test]
+    async fn rejects_spoofed_linear_url() {
+        // Subdomain spoofing
+        let result = run("fake-token", "https://uploads.linear.app.evil.com/file", ".").await;
+        assert!(result.is_err());
+
+        // Query param spoofing
+        let result =
+            run("fake-token", "https://evil.com?ref=uploads.linear.app", ".").await;
+        assert!(result.is_err());
     }
 }

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -51,17 +51,20 @@ mod tests {
     #[tokio::test]
     async fn rejects_spoofed_linear_url() {
         // Subdomain spoofing
-        let result = run("fake-token", "https://uploads.linear.app.evil.com/file", ".").await;
+        let result = run(
+            "fake-token",
+            "https://uploads.linear.app.evil.com/file",
+            ".",
+        )
+        .await;
         assert!(result.is_err());
 
         // Query param spoofing
-        let result =
-            run("fake-token", "https://evil.com?ref=uploads.linear.app", ".").await;
+        let result = run("fake-token", "https://evil.com?ref=uploads.linear.app", ".").await;
         assert!(result.is_err());
 
         // Path spoofing
-        let result =
-            run("fake-token", "https://evil.com/uploads.linear.app", ".").await;
+        let result = run("fake-token", "https://evil.com/uploads.linear.app", ".").await;
         assert!(result.is_err());
     }
 

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -29,3 +29,20 @@ pub async fn run(token: &str, url: &str, output: &str) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_non_linear_url() {
+        let result = run("fake-token", "https://example.com/file.csv", ".").await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("uploads.linear.app")
+        );
+    }
+}

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -1,0 +1,31 @@
+use anyhow::{Result, bail};
+
+use super::issue::{download_file, format_byte_size};
+use crate::output;
+
+pub async fn run(token: &str, url: &str, output: &str) -> Result<()> {
+    if !url.contains("uploads.linear.app") {
+        bail!("URL must be an uploads.linear.app link");
+    }
+
+    let output_dir = std::path::Path::new(output);
+    std::fs::create_dir_all(output_dir)?;
+
+    let client = reqwest::Client::new();
+    let mut used: Vec<String> = Vec::new();
+
+    match download_file(&client, url, token, output_dir, &mut used).await {
+        Ok((filename, size)) => {
+            output::print_success(&format!(
+                "Downloaded {} ({})",
+                filename,
+                format_byte_size(size)
+            ));
+        }
+        Err(e) => {
+            bail!("Download failed: {e}");
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -995,7 +995,11 @@ pub(crate) async fn download_file(
     used_filenames: &mut Vec<String>,
 ) -> Result<(String, usize)> {
     let mut request = client.get(url);
-    if url.contains("uploads.linear.app") {
+    if reqwest::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h == "uploads.linear.app"))
+        .unwrap_or(false)
+    {
         request = request.header("Authorization", token);
     }
     let response = request.send().await?;

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -987,6 +987,13 @@ pub async fn attachment_download(
     Ok(())
 }
 
+fn is_linear_upload_url(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h == "uploads.linear.app"))
+        .unwrap_or(false)
+}
+
 pub(crate) async fn download_file(
     client: &reqwest::Client,
     url: &str,
@@ -995,11 +1002,7 @@ pub(crate) async fn download_file(
     used_filenames: &mut Vec<String>,
 ) -> Result<(String, usize)> {
     let mut request = client.get(url);
-    if reqwest::Url::parse(url)
-        .ok()
-        .and_then(|u| u.host_str().map(|h| h == "uploads.linear.app"))
-        .unwrap_or(false)
-    {
+    if is_linear_upload_url(url) {
         request = request.header("Authorization", token);
     }
     let response = request.send().await?;
@@ -1189,5 +1192,34 @@ No link here."#;
         assert_eq!(format_byte_size(500), "500 B");
         assert_eq!(format_byte_size(1024), "1.0 KB");
         assert_eq!(format_byte_size(1024 * 1024 * 2), "2.0 MB");
+    }
+
+    #[test]
+    fn is_linear_upload_url_accepts_valid() {
+        assert!(is_linear_upload_url(
+            "https://uploads.linear.app/org/abc/def"
+        ));
+    }
+
+    #[test]
+    fn is_linear_upload_url_rejects_spoofed() {
+        // Subdomain spoofing
+        assert!(!is_linear_upload_url(
+            "https://uploads.linear.app.evil.com/file"
+        ));
+        // Query param spoofing
+        assert!(!is_linear_upload_url(
+            "https://evil.com?ref=uploads.linear.app"
+        ));
+        // Path spoofing
+        assert!(!is_linear_upload_url(
+            "https://evil.com/uploads.linear.app"
+        ));
+    }
+
+    #[test]
+    fn is_linear_upload_url_rejects_non_url() {
+        assert!(!is_linear_upload_url("not-a-url"));
+        assert!(!is_linear_upload_url(""));
     }
 }

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -1212,9 +1212,7 @@ No link here."#;
             "https://evil.com?ref=uploads.linear.app"
         ));
         // Path spoofing
-        assert!(!is_linear_upload_url(
-            "https://evil.com/uploads.linear.app"
-        ));
+        assert!(!is_linear_upload_url("https://evil.com/uploads.linear.app"));
     }
 
     #[test]

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -1022,7 +1022,7 @@ pub(crate) async fn download_file(
     Ok((filename, len))
 }
 
-pub(crate) fn deduplicate_filename(name: &str, used: &[String]) -> String {
+fn deduplicate_filename(name: &str, used: &[String]) -> String {
     if !used.contains(&name.to_string()) {
         return name.to_string();
     }
@@ -1043,7 +1043,7 @@ pub(crate) fn deduplicate_filename(name: &str, used: &[String]) -> String {
     }
 }
 
-pub(crate) fn content_disposition_filename(response: &reqwest::Response) -> Option<String> {
+fn content_disposition_filename(response: &reqwest::Response) -> Option<String> {
     let header = response.headers().get("content-disposition")?;
     let value = header.to_str().ok()?;
     // Parse: attachment; filename="name.ext" or filename=name.ext; ...

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -987,7 +987,7 @@ pub async fn attachment_download(
     Ok(())
 }
 
-async fn download_file(
+pub(crate) async fn download_file(
     client: &reqwest::Client,
     url: &str,
     token: &str,
@@ -1022,7 +1022,7 @@ async fn download_file(
     Ok((filename, len))
 }
 
-fn deduplicate_filename(name: &str, used: &[String]) -> String {
+pub(crate) fn deduplicate_filename(name: &str, used: &[String]) -> String {
     if !used.contains(&name.to_string()) {
         return name.to_string();
     }
@@ -1043,7 +1043,7 @@ fn deduplicate_filename(name: &str, used: &[String]) -> String {
     }
 }
 
-fn content_disposition_filename(response: &reqwest::Response) -> Option<String> {
+pub(crate) fn content_disposition_filename(response: &reqwest::Response) -> Option<String> {
     let header = response.headers().get("content-disposition")?;
     let value = header.to_str().ok()?;
     // Parse: attachment; filename="name.ext" or filename=name.ext; ...
@@ -1078,7 +1078,7 @@ fn extract_inline_upload_urls(text: &str) -> Vec<String> {
     results
 }
 
-fn format_byte_size(bytes: usize) -> String {
+pub(crate) fn format_byte_size(bytes: usize) -> String {
     if bytes < 1024 {
         format!("{} B", bytes)
     } else if bytes < 1024 * 1024 {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod changelog;
 pub mod comment;
 pub mod cycle;
+pub mod download;
 pub mod initiative;
 pub mod issue;
 pub mod label;

--- a/src/main.rs
+++ b/src/main.rs
@@ -469,8 +469,9 @@ async fn run(cli: Cli) -> Result<()> {
         }
 
         Commands::Download { url, output } => {
-            let ctx = ensure_auth(ws_flag, json, verbose)?;
-            commands::download::run(ctx.client.token(), &url, &output).await?;
+            let ws = workspace::resolve_workspace(ws_flag);
+            let token = auth::get_token(&ws)?;
+            commands::download::run(&token, &url, &output).await?;
         }
 
         Commands::Changelog => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,6 +468,11 @@ async fn run(cli: Cli) -> Result<()> {
             }
         }
 
+        Commands::Download { url, output } => {
+            let ctx = ensure_auth(ws_flag, json, verbose)?;
+            commands::download::run(ctx.client.token(), &url, &output).await?;
+        }
+
         Commands::Changelog => {
             let ctx = ensure_auth(ws_flag, json, verbose)?;
             commands::changelog::run(&ctx.client, ctx.json).await?;


### PR DESCRIPTION
## Summary
- Adds `lin download <URL> [-o dir]` for downloading files directly from `uploads.linear.app` URLs
- Reuses existing authenticated download helpers from the attachment download implementation
- No need to know the parent issue — just paste the URL

## Test plan
- [x] `cargo build` compiles cleanly
- [x] All 61 tests pass
- [ ] `lin download "https://uploads.linear.app/..." -o /tmp` downloads the file with correct filename