### PR TITLE
feat: Add cycle edit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `cycle edit` command with `--name`, `--description`, `--starts`, and `--ends` flags for updating cycle properties
+
 ## [0.7.0] - 2026-04-01
 
 ### Added

--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -457,6 +457,22 @@ pub const CYCLE_CREATE_MUTATION: &str = r#"
     }
 "#;
 
+pub const CYCLE_UPDATE_MUTATION: &str = r#"
+    mutation CycleUpdate($id: String!, $input: CycleUpdateInput!) {
+        cycleUpdate(id: $id, input: $input) {
+            success
+            cycle {
+                id
+                number
+                name
+                description
+                startsAt
+                endsAt
+            }
+        }
+    }
+"#;
+
 // --- Initiatives ---
 
 pub const INITIATIVES_QUERY: &str = r#"

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -561,6 +561,25 @@ pub struct CycleCreateData {
     pub cycle_create: CyclePayload,
 }
 
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CycleUpdateInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub starts_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ends_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CycleUpdateData {
+    pub cycle_update: CyclePayload,
+}
+
 // --- Initiatives ---
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1345,6 +1345,10 @@ mod tests {
             "Sprint 5",
             "--description",
             "Updated desc",
+            "--starts",
+            "2026-04-07",
+            "--ends",
+            "2026-04-14",
         ]);
         match cli.command {
             Commands::Cycle(CycleCommand::Edit {
@@ -1359,8 +1363,8 @@ mod tests {
                 assert_eq!(team, "eng");
                 assert_eq!(name.as_deref(), Some("Sprint 5"));
                 assert_eq!(description.as_deref(), Some("Updated desc"));
-                assert!(starts.is_none());
-                assert!(ends.is_none());
+                assert_eq!(starts.as_deref(), Some("2026-04-07"));
+                assert_eq!(ends.as_deref(), Some("2026-04-14"));
             }
             _ => panic!("expected Cycle Edit"),
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -626,6 +626,31 @@ pub enum CycleCommand {
         #[arg(long)]
         description: Option<String>,
     },
+    /// Edit a cycle's name or description
+    Edit {
+        /// Cycle name, number, or "current"
+        id: String,
+
+        /// Team name, key, or UUID
+        #[arg(long)]
+        team: String,
+
+        /// New cycle name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New cycle description
+        #[arg(long)]
+        description: Option<String>,
+
+        /// New start date (ISO 8601, e.g. 2026-04-07)
+        #[arg(long)]
+        starts: Option<String>,
+
+        /// New end date (ISO 8601, e.g. 2026-04-14)
+        #[arg(long)]
+        ends: Option<String>,
+    },
     /// View cycle details including issues
     Show {
         /// Cycle name, number, or "current"
@@ -1304,6 +1329,40 @@ mod tests {
                 assert_eq!(team, "eng");
             }
             _ => panic!("expected Cycle Show"),
+        }
+    }
+
+    #[test]
+    fn cycle_edit_parses() {
+        let cli = parse(&[
+            "lin",
+            "cycle",
+            "edit",
+            "current",
+            "--team",
+            "eng",
+            "--name",
+            "Sprint 5",
+            "--description",
+            "Updated desc",
+        ]);
+        match cli.command {
+            Commands::Cycle(CycleCommand::Edit {
+                id,
+                team,
+                name,
+                description,
+                starts,
+                ends,
+            }) => {
+                assert_eq!(id, "current");
+                assert_eq!(team, "eng");
+                assert_eq!(name.as_deref(), Some("Sprint 5"));
+                assert_eq!(description.as_deref(), Some("Updated desc"));
+                assert!(starts.is_none());
+                assert!(ends.is_none());
+            }
+            _ => panic!("expected Cycle Edit"),
         }
     }
 

--- a/src/commands/cycle.rs
+++ b/src/commands/cycle.rs
@@ -155,6 +155,82 @@ pub async fn create(
     Ok(())
 }
 
+pub async fn edit(
+    client: &LinearClient,
+    id: &str,
+    team: &str,
+    name: Option<String>,
+    description: Option<String>,
+    starts: Option<&str>,
+    ends: Option<&str>,
+    json_flag: bool,
+) -> Result<()> {
+    let team_id = resolve::resolve_team_identifier(client, team).await?;
+    let cycle_id = resolve::resolve_cycle_identifier(client, &team_id, id).await?;
+
+    let mut input = CycleUpdateInput::default();
+
+    if let Some(n) = name {
+        input.name = Some(n);
+    }
+    if let Some(d) = description {
+        input.description = Some(d);
+    }
+    if let Some(s) = starts {
+        input.starts_at = Some(date::parse_date(s)?);
+    }
+    if let Some(e) = ends {
+        input.ends_at = Some(date::parse_date(e)?);
+    }
+
+    if input.name.is_none()
+        && input.description.is_none()
+        && input.starts_at.is_none()
+        && input.ends_at.is_none()
+    {
+        bail!("No updates provided. Use --name, --description, --starts, or --ends.");
+    }
+
+    if json_flag {
+        let data = client
+            .execute_raw(
+                CYCLE_UPDATE_MUTATION,
+                Some(json!({ "id": cycle_id, "input": input })),
+            )
+            .await?;
+        output::print_json(&data);
+        return Ok(());
+    }
+
+    let data: CycleUpdateData = client
+        .execute(
+            CYCLE_UPDATE_MUTATION,
+            Some(json!({ "id": cycle_id, "input": input })),
+        )
+        .await?;
+
+    if !data.cycle_update.success {
+        bail!("Failed to update cycle");
+    }
+
+    if let Some(cycle) = data.cycle_update.cycle {
+        let label = cycle.name.as_deref().unwrap_or("(unnamed)");
+        let num = cycle.number.map(|n| format!(" #{}", n)).unwrap_or_default();
+        output::print_success(&format!("Updated cycle {}{}", label, num));
+        if let Some(ref desc) = cycle.description {
+            output::print_field("Description", desc);
+        }
+        if let Some(ref start) = cycle.starts_at {
+            output::print_field("Start", &output::format_date(start));
+        }
+        if let Some(ref end) = cycle.ends_at {
+            output::print_field("End", &output::format_date(end));
+        }
+    }
+
+    Ok(())
+}
+
 pub async fn show(client: &LinearClient, id: &str, team: &str, json_flag: bool) -> Result<()> {
     let team_id = resolve::resolve_team_identifier(client, team).await?;
     let cycle_id = resolve::resolve_cycle_identifier(client, &team_id, id).await?;

--- a/src/commands/cycle.rs
+++ b/src/commands/cycle.rs
@@ -141,20 +141,13 @@ pub async fn create(
     }
 
     if let Some(cycle) = data.cycle_create.cycle {
-        let label = cycle.name.as_deref().unwrap_or("(unnamed)");
-        let num = cycle.number.map(|n| format!(" #{}", n)).unwrap_or_default();
-        output::print_success(&format!("Created cycle {}{}", label, num));
-        if let Some(ref start) = cycle.starts_at {
-            output::print_field("Start", &output::format_date(start));
-        }
-        if let Some(ref end) = cycle.ends_at {
-            output::print_field("End", &output::format_date(end));
-        }
+        print_cycle_summary("Created", &cycle);
     }
 
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn edit(
     client: &LinearClient,
     id: &str,
@@ -168,28 +161,19 @@ pub async fn edit(
     let team_id = resolve::resolve_team_identifier(client, team).await?;
     let cycle_id = resolve::resolve_cycle_identifier(client, &team_id, id).await?;
 
-    let mut input = CycleUpdateInput::default();
+    let starts_at = starts.map(date::parse_date).transpose()?;
+    let ends_at = ends.map(date::parse_date).transpose()?;
 
-    if let Some(n) = name {
-        input.name = Some(n);
-    }
-    if let Some(d) = description {
-        input.description = Some(d);
-    }
-    if let Some(s) = starts {
-        input.starts_at = Some(date::parse_date(s)?);
-    }
-    if let Some(e) = ends {
-        input.ends_at = Some(date::parse_date(e)?);
-    }
-
-    if input.name.is_none()
-        && input.description.is_none()
-        && input.starts_at.is_none()
-        && input.ends_at.is_none()
-    {
+    if name.is_none() && description.is_none() && starts_at.is_none() && ends_at.is_none() {
         bail!("No updates provided. Use --name, --description, --starts, or --ends.");
     }
+
+    let input = CycleUpdateInput {
+        name,
+        description,
+        starts_at,
+        ends_at,
+    };
 
     if json_flag {
         let data = client
@@ -214,18 +198,7 @@ pub async fn edit(
     }
 
     if let Some(cycle) = data.cycle_update.cycle {
-        let label = cycle.name.as_deref().unwrap_or("(unnamed)");
-        let num = cycle.number.map(|n| format!(" #{}", n)).unwrap_or_default();
-        output::print_success(&format!("Updated cycle {}{}", label, num));
-        if let Some(ref desc) = cycle.description {
-            output::print_field("Description", desc);
-        }
-        if let Some(ref start) = cycle.starts_at {
-            output::print_field("Start", &output::format_date(start));
-        }
-        if let Some(ref end) = cycle.ends_at {
-            output::print_field("End", &output::format_date(end));
-        }
+        print_cycle_summary("Updated", &cycle);
     }
 
     Ok(())
@@ -315,6 +288,21 @@ pub async fn show(client: &LinearClient, id: &str, team: &str, json_flag: bool) 
     }
 
     Ok(())
+}
+
+fn print_cycle_summary(verb: &str, cycle: &Cycle) {
+    let label = cycle.name.as_deref().unwrap_or("(unnamed)");
+    let num = cycle.number.map(|n| format!(" #{}", n)).unwrap_or_default();
+    output::print_success(&format!("{} cycle {}{}", verb, label, num));
+    if let Some(ref desc) = cycle.description {
+        output::print_field("Description", desc);
+    }
+    if let Some(ref start) = cycle.starts_at {
+        output::print_field("Start", &output::format_date(start));
+    }
+    if let Some(ref end) = cycle.ends_at {
+        output::print_field("End", &output::format_date(end));
+    }
 }
 
 fn format_progress_bar(progress: f64, width: usize) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,6 +430,26 @@ async fn run(cli: Cli) -> Result<()> {
                     )
                     .await?;
                 }
+                CycleCommand::Edit {
+                    id,
+                    team,
+                    name,
+                    description,
+                    starts,
+                    ends,
+                } => {
+                    commands::cycle::edit(
+                        &ctx.client,
+                        &id,
+                        &team,
+                        name,
+                        description,
+                        starts.as_deref(),
+                        ends.as_deref(),
+                        ctx.json,
+                    )
+                    .await?;
+                }
                 CycleCommand::Show { id, team } => {
                     commands::cycle::show(&ctx.client, &id, &team, ctx.json).await?;
                 }


### PR DESCRIPTION
## Summary

- Adds `lin cycle edit <id> --team <team>` command with `--name`, `--description`, `--starts`, and `--ends` flags
- Adds `CycleUpdateInput` type and `CYCLE_UPDATE_MUTATION` GraphQL mutation
- Includes CLI parser test for the new subcommand

Closes #32

## Test plan

- [ ] `lin cycle edit current --team ENG --name "Sprint 5"` updates the cycle name
- [ ] `lin cycle edit 3 --team ENG --description "New desc"` updates description
- [ ] `lin cycle edit current --team ENG` with no flags shows error
- [ ] `--json` flag returns raw API response