### PR TITLE
fix: Paginate label queries to find all workspace labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `cycle edit` command with `--name`, `--description`, `--starts`, and `--ends` flags for updating cycle properties
 
+### Fixed
+- `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page
+
 ## [0.7.0] - 2026-04-01
 
 ### Added

--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -311,12 +311,16 @@ pub const USERS_QUERY: &str = r#"
 // --- Labels ---
 
 pub const LABELS_QUERY: &str = r#"
-    query IssueLabels($filter: IssueLabelFilter) {
-        issueLabels(filter: $filter) {
+    query IssueLabels($filter: IssueLabelFilter, $first: Int, $after: String) {
+        issueLabels(filter: $filter, first: $first, after: $after) {
             nodes {
                 id
                 name
                 color
+            }
+            pageInfo {
+                hasNextPage
+                endCursor
             }
         }
     }

--- a/src/api/resolve.rs
+++ b/src/api/resolve.rs
@@ -293,6 +293,9 @@ pub async fn fetch_all_labels(
 
         if data.issue_labels.page_info.has_next_page {
             after = data.issue_labels.page_info.end_cursor;
+            if after.is_none() {
+                break;
+            }
         } else {
             break;
         }

--- a/src/api/resolve.rs
+++ b/src/api/resolve.rs
@@ -287,9 +287,7 @@ pub async fn fetch_all_labels(
             vars["after"] = json!(cursor);
         }
 
-        let data: LabelsData = client
-            .execute(LABELS_QUERY, Some(vars))
-            .await?;
+        let data: LabelsData = client.execute(LABELS_QUERY, Some(vars)).await?;
 
         all_labels.extend(data.issue_labels.nodes);
 

--- a/src/api/resolve.rs
+++ b/src/api/resolve.rs
@@ -245,10 +245,9 @@ pub async fn resolve_cycle_identifier(
 }
 
 /// Resolve label names to label IDs via case-insensitive matching.
+/// Paginates through all workspace labels to avoid missing any.
 pub async fn resolve_label_names(client: &LinearClient, names: &[String]) -> Result<Vec<String>> {
-    let data: LabelsData = client.execute(LABELS_QUERY, None).await?;
-
-    let all_labels = data.issue_labels.nodes;
+    let all_labels = fetch_all_labels(client, None).await?;
     let mut ids = Vec::new();
 
     for name in names {
@@ -269,4 +268,37 @@ pub async fn resolve_label_names(client: &LinearClient, names: &[String]) -> Res
     }
 
     Ok(ids)
+}
+
+/// Fetch all labels, paginating through all pages.
+pub async fn fetch_all_labels(
+    client: &LinearClient,
+    filter: Option<serde_json::Value>,
+) -> Result<Vec<Label>> {
+    let mut all_labels: Vec<Label> = Vec::new();
+    let mut after: Option<String> = None;
+
+    loop {
+        let mut vars = json!({ "first": 250 });
+        if let Some(ref f) = filter {
+            vars["filter"] = f.clone();
+        }
+        if let Some(ref cursor) = after {
+            vars["after"] = json!(cursor);
+        }
+
+        let data: LabelsData = client
+            .execute(LABELS_QUERY, Some(vars))
+            .await?;
+
+        all_labels.extend(data.issue_labels.nodes);
+
+        if data.issue_labels.page_info.has_next_page {
+            after = data.issue_labels.page_info.end_cursor;
+        } else {
+            break;
+        }
+    }
+
+    Ok(all_labels)
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -45,7 +45,7 @@ pub struct Team {
 
 // --- Label ---
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Label {
     pub id: String,
     pub name: String,
@@ -391,12 +391,28 @@ pub struct UsersData {
     pub users: Connection<User>,
 }
 
+// --- Pagination ---
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PageInfo {
+    pub has_next_page: bool,
+    pub end_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginatedConnection<T> {
+    pub nodes: Vec<T>,
+    pub page_info: PageInfo,
+}
+
 // --- Labels ---
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelsData {
-    pub issue_labels: Connection<Label>,
+    pub issue_labels: PaginatedConnection<Label>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -7,30 +7,26 @@ use crate::api::resolve;
 use crate::api::types::*;
 use crate::output;
 
-pub async fn list(client: &LinearClient, team: Option<&str>, json: bool) -> Result<()> {
-    let variables = match team {
+pub async fn list(client: &LinearClient, team: Option<&str>, json_output: bool) -> Result<()> {
+    let filter = match team {
         Some(t) => {
             let tid = resolve::resolve_team_identifier(client, t).await?;
             Some(json!({
-                "filter": {
-                    "team": {
-                        "id": { "eq": tid }
-                    }
+                "team": {
+                    "id": { "eq": tid }
                 }
             }))
         }
         None => None,
     };
 
-    if json {
-        let data = client.execute_raw(LABELS_QUERY, variables).await?;
-        output::print_json(&data);
+    let labels = resolve::fetch_all_labels(client, filter).await?;
+
+    if json_output {
+        output::print_json(&serde_json::to_value(&labels)?);
         return Ok(());
     }
 
-    let data: LabelsData = client.execute(LABELS_QUERY, variables).await?;
-
-    let labels = data.issue_labels.nodes;
     output::print_header(&format!("Labels ({})", labels.len()));
 
     let headers = &["Name", "Color"];


### PR DESCRIPTION
## Summary

Closes #35

- Label name resolver now paginates through all pages (cursor-based, 250 per page) instead of fetching only the first page
- `label list` also paginates, so it shows every workspace label
- Added `PageInfo` and `PaginatedConnection<T>` types for reuse

## Test plan

- [ ] `lin label list` — verify count matches Linear UI
- [ ] `lin label list --team <team>` — filtered list also complete
- [ ] `lin issue edit <id> --label RMD` — previously broken, should now resolve
- [ ] `lin label list --json | jq length` — confirm all labels returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)