### PR TITLE
feat: Support threaded comment replies (parentId)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `cycle edit` command with `--name`, `--description`, `--starts`, and `--ends` flags for updating cycle properties
 - `lin download <URL>` command to download files directly from `uploads.linear.app` URLs without needing the parent issue
+- `comment add --parent <comment-id>` and `issue comment --parent <comment-id>` flags to nest a reply under an existing comment via Linear's `commentCreate` `parentId` input
+- `comment reply <comment-id> <body>` subcommand that looks up the parent comment's issue automatically, so replies only need the parent comment UUID
 
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page

--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -130,6 +130,15 @@ pub const COMMENTS_QUERY: &str = r#"
     }
 "#;
 
+pub const COMMENT_BY_ID_QUERY: &str = r#"
+    query Comment($id: String!) {
+        comment(id: $id) {
+            id
+            issue { id }
+        }
+    }
+"#;
+
 pub const COMMENT_CREATE_MUTATION: &str = r#"
     mutation CommentCreate($input: CommentCreateInput!) {
         commentCreate(input: $input) {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -235,6 +235,22 @@ pub struct CommentPayload {
     pub comment: Option<Comment>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct CommentByIdData {
+    pub comment: Option<CommentWithIssue>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommentWithIssue {
+    pub id: String,
+    pub issue: CommentIssueRef,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommentIssueRef {
+    pub id: String,
+}
+
 // --- Project (extended) ---
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -362,6 +362,10 @@ pub enum IssueCommand {
         /// Attach a file (uploads and embeds markdown link in body)
         #[arg(long)]
         attachment: Option<String>,
+
+        /// Reply under an existing comment (parent comment UUID)
+        #[arg(long)]
+        parent: Option<String>,
     },
 }
 
@@ -428,6 +432,21 @@ pub enum CommentCommand {
         /// Issue identifier
         id: String,
         /// Comment body
+        body: String,
+
+        /// Attach a file (uploads and embeds markdown link in body)
+        #[arg(long)]
+        attachment: Option<String>,
+
+        /// Reply under an existing comment (parent comment UUID)
+        #[arg(long)]
+        parent: Option<String>,
+    },
+    /// Reply to an existing comment (looks up the issue automatically)
+    Reply {
+        /// Parent comment UUID (get via `lin comment view --show-ids`)
+        id: String,
+        /// Reply body
         body: String,
 
         /// Attach a file (uploads and embeds markdown link in body)
@@ -704,10 +723,12 @@ mod tests {
                 id,
                 body,
                 attachment,
+                parent,
             }) => {
                 assert_eq!(id, "ENG-123");
                 assert_eq!(body, "Hello world");
                 assert!(attachment.is_none());
+                assert!(parent.is_none());
             }
             _ => panic!("expected Issue Comment"),
         }
@@ -727,6 +748,25 @@ mod tests {
         match cli.command {
             Commands::Issue(IssueCommand::Comment { attachment, .. }) => {
                 assert_eq!(attachment.as_deref(), Some("file.png"));
+            }
+            _ => panic!("expected Issue Comment"),
+        }
+    }
+
+    #[test]
+    fn issue_comment_with_parent() {
+        let cli = parse(&[
+            "lin",
+            "issue",
+            "comment",
+            "ENG-1",
+            "nested reply",
+            "--parent",
+            "abc123-parent",
+        ]);
+        match cli.command {
+            Commands::Issue(IssueCommand::Comment { parent, .. }) => {
+                assert_eq!(parent.as_deref(), Some("abc123-parent"));
             }
             _ => panic!("expected Issue Comment"),
         }
@@ -828,11 +868,97 @@ mod tests {
     fn top_level_comment_add_still_works() {
         let cli = parse(&["lin", "comment", "add", "ENG-1", "top level comment"]);
         match cli.command {
-            Commands::Comment(CommentCommand::Add { id, body, .. }) => {
+            Commands::Comment(CommentCommand::Add {
+                id, body, parent, ..
+            }) => {
                 assert_eq!(id, "ENG-1");
                 assert_eq!(body, "top level comment");
+                assert!(parent.is_none());
             }
             _ => panic!("expected Comment Add"),
+        }
+    }
+
+    #[test]
+    fn comment_add_with_parent_parses() {
+        let cli = parse(&[
+            "lin",
+            "comment",
+            "add",
+            "ENG-1",
+            "nested reply",
+            "--parent",
+            "parent-uuid",
+        ]);
+        match cli.command {
+            Commands::Comment(CommentCommand::Add {
+                id, body, parent, ..
+            }) => {
+                assert_eq!(id, "ENG-1");
+                assert_eq!(body, "nested reply");
+                assert_eq!(parent.as_deref(), Some("parent-uuid"));
+            }
+            _ => panic!("expected Comment Add"),
+        }
+    }
+
+    #[test]
+    fn comment_add_parent_and_attachment() {
+        let cli = parse(&[
+            "lin",
+            "comment",
+            "add",
+            "ENG-1",
+            "reply with file",
+            "--parent",
+            "parent-uuid",
+            "--attachment",
+            "shot.png",
+        ]);
+        match cli.command {
+            Commands::Comment(CommentCommand::Add {
+                parent, attachment, ..
+            }) => {
+                assert_eq!(parent.as_deref(), Some("parent-uuid"));
+                assert_eq!(attachment.as_deref(), Some("shot.png"));
+            }
+            _ => panic!("expected Comment Add"),
+        }
+    }
+
+    #[test]
+    fn comment_reply_parses() {
+        let cli = parse(&["lin", "comment", "reply", "parent-uuid", "reply body"]);
+        match cli.command {
+            Commands::Comment(CommentCommand::Reply {
+                id,
+                body,
+                attachment,
+            }) => {
+                assert_eq!(id, "parent-uuid");
+                assert_eq!(body, "reply body");
+                assert!(attachment.is_none());
+            }
+            _ => panic!("expected Comment Reply"),
+        }
+    }
+
+    #[test]
+    fn comment_reply_with_attachment() {
+        let cli = parse(&[
+            "lin",
+            "comment",
+            "reply",
+            "parent-uuid",
+            "reply body",
+            "--attachment",
+            "shot.png",
+        ]);
+        match cli.command {
+            Commands::Comment(CommentCommand::Reply { attachment, .. }) => {
+                assert_eq!(attachment.as_deref(), Some("shot.png"));
+            }
+            _ => panic!("expected Comment Reply"),
         }
     }
 

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -56,6 +56,7 @@ pub async fn add(
     issue_id: &str,
     body: &str,
     attachment_path: Option<&str>,
+    parent_id: Option<&str>,
 ) -> Result<()> {
     let mut final_body = body.to_string();
 
@@ -69,10 +70,13 @@ pub async fn add(
         final_body = format!("{}\n\n[{}]({})", final_body, filename, asset_url);
     }
 
-    let input = json!({
+    let mut input = json!({
         "issueId": issue_id,
         "body": final_body,
     });
+    if let Some(parent) = parent_id {
+        input["parentId"] = json!(parent);
+    }
 
     let data: CommentCreateData = client
         .execute(COMMENT_CREATE_MUTATION, Some(json!({ "input": input })))
@@ -82,8 +86,39 @@ pub async fn add(
         bail!("Failed to create comment");
     }
 
-    output::print_success("Comment added");
+    if parent_id.is_some() {
+        output::print_success("Reply added");
+    } else {
+        output::print_success("Comment added");
+    }
     Ok(())
+}
+
+pub async fn reply(
+    client: &LinearClient,
+    parent_comment_id: &str,
+    body: &str,
+    attachment_path: Option<&str>,
+) -> Result<()> {
+    let data: CommentByIdData = client
+        .execute(
+            COMMENT_BY_ID_QUERY,
+            Some(json!({ "id": parent_comment_id })),
+        )
+        .await?;
+
+    let parent = data
+        .comment
+        .ok_or_else(|| anyhow::anyhow!("Comment '{}' not found", parent_comment_id))?;
+
+    add(
+        client,
+        &parent.issue.id,
+        body,
+        attachment_path,
+        Some(&parent.id),
+    )
+    .await
 }
 
 pub async fn edit(

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ async fn run(cli: Cli) -> Result<()> {
                     )
                     .await?;
                     if let Some(body) = comment {
-                        commands::comment::add(&ctx.client, &id, &body, None).await?;
+                        commands::comment::add(&ctx.client, &id, &body, None, None).await?;
                     }
                 }
                 IssueCommand::Search {
@@ -260,8 +260,16 @@ async fn run(cli: Cli) -> Result<()> {
                     id,
                     body,
                     attachment,
+                    parent,
                 } => {
-                    commands::comment::add(&ctx.client, &id, &body, attachment.as_deref()).await?;
+                    commands::comment::add(
+                        &ctx.client,
+                        &id,
+                        &body,
+                        attachment.as_deref(),
+                        parent.as_deref(),
+                    )
+                    .await?;
                 }
             }
         }
@@ -276,8 +284,24 @@ async fn run(cli: Cli) -> Result<()> {
                     id,
                     body,
                     attachment,
+                    parent,
                 } => {
-                    commands::comment::add(&ctx.client, &id, &body, attachment.as_deref()).await?;
+                    commands::comment::add(
+                        &ctx.client,
+                        &id,
+                        &body,
+                        attachment.as_deref(),
+                        parent.as_deref(),
+                    )
+                    .await?;
+                }
+                CommentCommand::Reply {
+                    id,
+                    body,
+                    attachment,
+                } => {
+                    commands::comment::reply(&ctx.client, &id, &body, attachment.as_deref())
+                        .await?;
                 }
                 CommentCommand::Edit {
                     id,


### PR DESCRIPTION
## Summary
- Adds `--parent <comment-id>` to `lin comment add` and `lin issue comment` so agents can nest replies under an existing comment via Linear's `commentCreate` `parentId` input.
- Adds `lin comment reply <comment-id> <body>` as a convenience: it fetches the parent comment to resolve the issue ID automatically, so callers only need the parent UUID (discoverable via `comment view --show-ids`).
- `commentCreate` is called with both `issueId` and `parentId` set on replies, which matches Linear's schema and keeps the reply attached to the parent thread.

Closes #37

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 75 passed, including 5 new CLI parse tests:
  - `issue_comment_with_parent`
  - `comment_add_with_parent_parses`
  - `comment_add_parent_and_attachment`
  - `comment_reply_parses`
  - `comment_reply_with_attachment`
- [ ] Manual: `lin comment reply <uuid> "..."` against a real Linear workspace (not run here — no token available in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)