### PR TITLE
fix: truncate on char boundaries in cycle output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page
+- `cycle show` no longer panics when an issue title contains a multi-byte UTF-8 character (e.g. em dash) at the truncation boundary
 
 ## [0.7.0] - 2026-04-01
 

--- a/src/commands/cycle.rs
+++ b/src/commands/cycle.rs
@@ -312,9 +312,33 @@ fn format_progress_bar(progress: f64, width: usize) -> String {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    if s.chars().count() <= max {
         s.to_string()
     } else {
-        format!("{}…", &s[..max - 1])
+        let prefix: String = s.chars().take(max - 1).collect();
+        format!("{prefix}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_splits_on_char_boundary() {
+        let s = "Submit Block Trading request is unauthenticated — 401s before reaching Schwab";
+        let out = truncate(s, 50);
+        assert_eq!(out.chars().count(), 50);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 50), "hello");
+    }
+
+    #[test]
+    fn truncate_multibyte_under_limit() {
+        assert_eq!(truncate("héllo — world", 50), "héllo — world");
     }
 }


### PR DESCRIPTION
## Summary
- `cycle show` panicked when an issue title contained a multi-byte UTF-8 character (e.g. em dash) at the truncation boundary — `truncate` sliced by byte index.
- Switched to `chars().count()` / `chars().take()` so the cut always lands on a char boundary.
- Added unit tests covering the original panic case, short strings, and multi-byte strings under the limit.

## Test plan
- [x] `cargo test` (73 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Repro'd the original panic with `lin cycle show 5 -w advicecloud --team APP`; no longer panics after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)