### PR TITLE
feat: project create/edit support for start and target dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lin download <URL>` command to download files directly from `uploads.linear.app` URLs without needing the parent issue
 - `comment add --parent <comment-id>` and `issue comment --parent <comment-id>` flags to nest a reply under an existing comment via Linear's `commentCreate` `parentId` input
 - `comment reply <comment-id> <body>` subcommand that looks up the parent comment's issue automatically, so replies only need the parent comment UUID
+- `project create` and `project edit` `--start` and `--target` (alias `--end`) flags for setting project start and target dates (accepts `YYYY-MM-DD` or relative shorthand like `3d`, `1w`)
 
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -499,6 +499,14 @@ pub enum ProjectCommand {
         /// Project description
         #[arg(long)]
         description: Option<String>,
+
+        /// Start date (YYYY-MM-DD or relative like 3d, 1w)
+        #[arg(long)]
+        start: Option<String>,
+
+        /// Target/end date (YYYY-MM-DD or relative like 3d, 1w)
+        #[arg(long, alias = "end")]
+        target: Option<String>,
     },
     /// Edit a project
     Edit {
@@ -520,6 +528,14 @@ pub enum ProjectCommand {
         /// New state (e.g., planned, started, paused, completed, canceled)
         #[arg(long)]
         state: Option<String>,
+
+        /// New start date (YYYY-MM-DD or relative like 3d, 1w)
+        #[arg(long)]
+        start: Option<String>,
+
+        /// New target/end date (YYYY-MM-DD or relative like 3d, 1w)
+        #[arg(long, alias = "end")]
+        target: Option<String>,
     },
     /// Manage project updates
     #[command(subcommand)]
@@ -1379,6 +1395,78 @@ mod tests {
                 assert!(content);
             }
             _ => panic!("expected Project View"),
+        }
+    }
+
+    #[test]
+    fn project_create_with_dates() {
+        let cli = parse(&[
+            "lin",
+            "project",
+            "create",
+            "March 2026",
+            "--teams",
+            "eng",
+            "--start",
+            "2026-03-01",
+            "--target",
+            "2026-03-31",
+        ]);
+        match cli.command {
+            Commands::Project(ProjectCommand::Create {
+                name,
+                start,
+                target,
+                ..
+            }) => {
+                assert_eq!(name, "March 2026");
+                assert_eq!(start.as_deref(), Some("2026-03-01"));
+                assert_eq!(target.as_deref(), Some("2026-03-31"));
+            }
+            _ => panic!("expected Project Create"),
+        }
+    }
+
+    #[test]
+    fn project_edit_with_dates() {
+        let cli = parse(&[
+            "lin",
+            "project",
+            "edit",
+            "March 2026",
+            "--start",
+            "2026-03-01",
+            "--target",
+            "2026-03-31",
+        ]);
+        match cli.command {
+            Commands::Project(ProjectCommand::Edit {
+                id, start, target, ..
+            }) => {
+                assert_eq!(id, "March 2026");
+                assert_eq!(start.as_deref(), Some("2026-03-01"));
+                assert_eq!(target.as_deref(), Some("2026-03-31"));
+            }
+            _ => panic!("expected Project Edit"),
+        }
+    }
+
+    #[test]
+    fn project_edit_end_alias() {
+        let cli = parse(&[
+            "lin",
+            "project",
+            "edit",
+            "March 2026",
+            "--end",
+            "2026-03-31",
+        ]);
+        match cli.command {
+            Commands::Project(ProjectCommand::Edit { id, target, .. }) => {
+                assert_eq!(id, "March 2026");
+                assert_eq!(target.as_deref(), Some("2026-03-31"));
+            }
+            _ => panic!("expected Project Edit"),
         }
     }
 

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -5,6 +5,7 @@ use crate::api::client::LinearClient;
 use crate::api::queries::*;
 use crate::api::resolve;
 use crate::api::types::*;
+use crate::date;
 use crate::output;
 
 pub async fn list(
@@ -109,6 +110,8 @@ pub async fn create(
     name: &str,
     teams: &[String],
     description: Option<&str>,
+    start: Option<&str>,
+    target: Option<&str>,
 ) -> Result<()> {
     let mut resolved_team_ids = Vec::new();
     for t in teams {
@@ -122,6 +125,12 @@ pub async fn create(
 
     if let Some(desc) = description {
         input["description"] = json!(desc);
+    }
+    if let Some(s) = start {
+        input["startDate"] = json!(date::parse_date_only(s)?);
+    }
+    if let Some(t) = target {
+        input["targetDate"] = json!(date::parse_date_only(t)?);
     }
 
     let data: ProjectCreateData = client
@@ -139,6 +148,7 @@ pub async fn create(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn edit(
     client: &LinearClient,
     id: &str,
@@ -146,6 +156,8 @@ pub async fn edit(
     description: Option<&str>,
     content: Option<&str>,
     state: Option<&str>,
+    start: Option<&str>,
+    target: Option<&str>,
 ) -> Result<()> {
     let id = resolve::resolve_project_identifier(client, id).await?;
     let mut input = json!({});
@@ -160,6 +172,12 @@ pub async fn edit(
     }
     if let Some(s) = state {
         input["state"] = json!(s);
+    }
+    if let Some(s) = start {
+        input["startDate"] = json!(date::parse_date_only(s)?);
+    }
+    if let Some(t) = target {
+        input["targetDate"] = json!(date::parse_date_only(t)?);
     }
 
     let data: ProjectUpdateMutationData = client

--- a/src/date.rs
+++ b/src/date.rs
@@ -69,6 +69,16 @@ pub fn parse_date(input: &str) -> Result<String> {
     )
 }
 
+/// Parses a date string and returns it as YYYY-MM-DD (TimelessDate).
+///
+/// Accepts the same inputs as [`parse_date`] but discards the time portion.
+/// Use this for Linear API fields typed as `TimelessDate` (e.g., project
+/// `startDate` / `targetDate`).
+pub fn parse_date_only(input: &str) -> Result<String> {
+    let full = parse_date(input)?;
+    Ok(full[..10].to_string())
+}
+
 /// Adds a relative duration (e.g., "1w", "10d") to an ISO 8601 date string.
 pub fn add_duration_to_date(date_str: &str, duration_str: &str) -> Result<String> {
     let duration = parse_relative(duration_str).ok_or_else(|| {
@@ -184,5 +194,31 @@ mod tests {
     #[test]
     fn add_duration_invalid() {
         assert!(add_duration_to_date("2026-04-01", "abc").is_err());
+    }
+
+    #[test]
+    fn parse_date_only_iso() {
+        assert_eq!(parse_date_only("2026-03-24").unwrap(), "2026-03-24");
+    }
+
+    #[test]
+    fn parse_date_only_iso_datetime() {
+        assert_eq!(
+            parse_date_only("2026-03-24T10:30:00Z").unwrap(),
+            "2026-03-24"
+        );
+    }
+
+    #[test]
+    fn parse_date_only_relative() {
+        let result = parse_date_only("3d").unwrap();
+        assert_eq!(result.len(), 10);
+        assert_eq!(result.chars().nth(4), Some('-'));
+        assert_eq!(result.chars().nth(7), Some('-'));
+    }
+
+    #[test]
+    fn parse_date_only_invalid() {
+        assert!(parse_date_only("not-a-date").is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,9 +329,18 @@ async fn run(cli: Cli) -> Result<()> {
                     name,
                     teams,
                     description,
+                    start,
+                    target,
                 } => {
-                    commands::project::create(&ctx.client, &name, &teams, description.as_deref())
-                        .await?;
+                    commands::project::create(
+                        &ctx.client,
+                        &name,
+                        &teams,
+                        description.as_deref(),
+                        start.as_deref(),
+                        target.as_deref(),
+                    )
+                    .await?;
                 }
                 ProjectCommand::Edit {
                     id,
@@ -339,6 +348,8 @@ async fn run(cli: Cli) -> Result<()> {
                     description,
                     content,
                     state,
+                    start,
+                    target,
                 } => {
                     commands::project::edit(
                         &ctx.client,
@@ -347,6 +358,8 @@ async fn run(cli: Cli) -> Result<()> {
                         description.as_deref(),
                         content.as_deref(),
                         state.as_deref(),
+                        start.as_deref(),
+                        target.as_deref(),
                     )
                     .await?;
                 }


### PR DESCRIPTION
Closes #41

## Summary
- Adds `--start` and `--target` (alias `--end`) flags to `lin project create` and `lin project edit` for setting Linear project start/target dates
- Both flags accept ISO dates (`YYYY-MM-DD`) or relative shorthand (`3d`, `1w`), parsed through a new `date::parse_date_only` helper that returns `TimelessDate` (`YYYY-MM-DD`) for the Linear `ProjectInput.startDate` / `targetDate` fields

## Test plan
- [x] `cargo test` (85 tests pass, including new CLI parse tests for `--start`/`--target`/`--end` and `parse_date_only` unit tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: `lin project create "Q3 2026" --teams eng --start 2026-07-01 --target 2026-09-30`
- [ ] Manual: `lin project edit "Q3 2026" --end 2026-10-15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)