### PR TITLE
fix: truncate on char boundaries across list outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page
-- `cycle show` no longer panics when an issue title contains a multi-byte UTF-8 character (e.g. em dash) at the truncation boundary
-- `issue list` no longer panics when an issue title contains a multi-byte UTF-8 character (e.g. em dash) at the truncation boundary
+- `cycle show`, `issue list`, `initiative list`, and `changelog` no longer panic when a title contains a multi-byte UTF-8 character (e.g. em dash) at the truncation boundary
 
 ## [0.7.0] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page
 - `cycle show` no longer panics when an issue title contains a multi-byte UTF-8 character (e.g. em dash) at the truncation boundary
+- `issue list` no longer panics when an issue title contains a multi-byte UTF-8 character (e.g. em dash) at the truncation boundary
 
 ## [0.7.0] - 2026-04-01
 

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -51,9 +51,28 @@ pub async fn run(client: &LinearClient, json: bool) -> Result<()> {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    if s.chars().count() <= max {
         s.to_string()
     } else {
-        format!("{}…", &s[..max - 1])
+        let prefix: String = s.chars().take(max - 1).collect();
+        format!("{prefix}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_splits_on_char_boundary() {
+        let s = "Submit Block Trading request is unauthenticated — 401s before reaching Schwab";
+        let out = truncate(s, 50);
+        assert_eq!(out.chars().count(), 50);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 50), "hello");
     }
 }

--- a/src/commands/initiative.rs
+++ b/src/commands/initiative.rs
@@ -85,9 +85,28 @@ pub async fn view(client: &LinearClient, id: &str, json: bool) -> Result<()> {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    if s.chars().count() <= max {
         s.to_string()
     } else {
-        format!("{}…", &s[..max - 1])
+        let prefix: String = s.chars().take(max - 1).collect();
+        format!("{prefix}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_splits_on_char_boundary() {
+        let s = "Submit Block Trading request is unauthenticated — 401s before reaching Schwab";
+        let out = truncate(s, 50);
+        assert_eq!(out.chars().count(), 50);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 50), "hello");
     }
 }

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -1119,10 +1119,11 @@ fn print_issues_table(issues: &[Issue]) {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    if s.chars().count() <= max {
         s.to_string()
     } else {
-        format!("{}…", &s[..max - 1])
+        let prefix: String = s.chars().take(max - 1).collect();
+        format!("{prefix}…")
     }
 }
 
@@ -1219,5 +1220,23 @@ No link here."#;
     fn is_linear_upload_url_rejects_non_url() {
         assert!(!is_linear_upload_url("not-a-url"));
         assert!(!is_linear_upload_url(""));
+    }
+
+    #[test]
+    fn truncate_splits_on_char_boundary() {
+        let s = "Submit Block Trading request is unauthenticated — 401s before reaching Schwab";
+        let out = truncate(s, 50);
+        assert_eq!(out.chars().count(), 50);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 50), "hello");
+    }
+
+    #[test]
+    fn truncate_multibyte_under_limit() {
+        assert_eq!(truncate("héllo — world", 50), "héllo — world");
     }
 }


### PR DESCRIPTION
## Summary
- `lin issue list`, `initiative list`, and `changelog` panicked when a title contained a multi-byte UTF-8 character (e.g. em dash) at the 50-char truncation boundary, because `truncate` sliced by byte index.
- All three callsites now use `chars().count()` for length and `chars().take(max-1).collect()` for the prefix, so the function is valid for any UTF-8 input.
- Mirrors the same fix applied to cycle output in #39 (which left these three identical copies un-fixed).

## Files touched
- `src/commands/issue.rs` — `truncate` + 3 tests (em-dash boundary, short-string passthrough, multibyte under limit)
- `src/commands/initiative.rs` — `truncate` + 2 tests
- `src/commands/changelog.rs` — `truncate` + 2 tests
- `CHANGELOG.md` — Unreleased/Fixed entry

## Test plan
- [x] `cargo test` — 68 passed (7 new across the three modules)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Manual: `lin issue list` against an issue with an em dash in its title no longer panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)