### PR TITLE
feat: include cycle in issue list JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `comment add --parent <comment-id>` and `issue comment --parent <comment-id>` flags to nest a reply under an existing comment via Linear's `commentCreate` `parentId` input
 - `comment reply <comment-id> <body>` subcommand that looks up the parent comment's issue automatically, so replies only need the parent comment UUID
 - `project create` and `project edit` `--start` and `--target` (alias `--end`) flags for setting project start and target dates (accepts `YYYY-MM-DD` or relative shorthand like `3d`, `1w`)
+- `issue list` JSON output now includes the `cycle` field (id, number, name) for each issue
 
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page

--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -62,6 +62,7 @@ pub const ISSUES_QUERY: &str = r#"
                 state { id name type }
                 assignee { id name displayName }
                 team { id name key }
+                cycle { id number name }
             }
         }
     }


### PR DESCRIPTION
## Summary
- `ISSUES_QUERY` didn't request the `cycle` field, so `lin --json issue list` returned issues with no cycle data — callers had to fall back to per-issue lookups to recover it.
- Add `cycle { id number name }` to the query node selection.
- Typed path already handles `Option<CycleRef>` on `Issue`, so no struct changes are required.

## Out of scope
- The default table output (`lin issue list` without `--json`) doesn't add a Cycle column. Happy to follow up if wanted.
- `ISSUE_SEARCH_QUERY` has the same omission; left alone here to keep the diff minimal.

## Test plan
- [x] `cargo build` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Manual: `lin --json issue list --team APP --limit 5` returns `cycle` populated on issues that have one, `null` otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)