### PR TITLE
feat(issue): add `issue relation` command (blocks/duplicate/related)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `comment reply <comment-id> <body>` subcommand that looks up the parent comment's issue automatically, so replies only need the parent comment UUID
 - `project create` and `project edit` `--start` and `--target` (alias `--end`) flags for setting project start and target dates (accepts `YYYY-MM-DD` or relative shorthand like `3d`, `1w`)
 - `issue list` JSON output now includes the `cycle` field (id, number, name) for each issue
+- `issue relation <issue> <blocks|duplicate|related> <related>` command to link two issues via Linear's `issueRelationCreate` mutation; also unblocks setting the `Duplicate` workflow state, which Linear rejects unless a duplicate relation already exists (#46)
 
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ lin issue attachments list ENG-123
 lin issue attachments add ENG-123 screenshot.png
 lin issue attachments download ENG-123 -o /tmp/
 lin issue attachments download ENG-123 --attachment-id f17b -o /tmp/
+lin issue relation ENG-123 duplicate ENG-456   # ENG-123 is a duplicate of ENG-456
+lin issue relation ENG-123 blocks ENG-456      # ENG-123 blocks ENG-456
+lin issue relation ENG-123 related ENG-456     # ENG-123 relates to ENG-456
 ```
 
 ### Comments

--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -164,6 +164,20 @@ pub const COMMENT_UPDATE_MUTATION: &str = r#"
     }
 "#;
 
+// --- Issue relations ---
+
+pub const ISSUE_RELATION_CREATE_MUTATION: &str = r#"
+    mutation IssueRelationCreate($input: IssueRelationCreateInput!) {
+        issueRelationCreate(input: $input) {
+            success
+            issueRelation {
+                id
+                type
+            }
+        }
+    }
+"#;
+
 // --- Projects ---
 
 pub const PROJECTS_QUERY: &str = r#"

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -161,7 +161,7 @@ pub struct IssueUpdateData {
 
 // --- Issue relations ---
 
-#[derive(Debug, Serialize, Default)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IssueRelationCreateInput {
     pub issue_id: String,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -159,6 +159,37 @@ pub struct IssueUpdateData {
     pub issue_update: IssuePayload,
 }
 
+// --- Issue relations ---
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueRelationCreateInput {
+    pub issue_id: String,
+    pub related_issue_id: String,
+    #[serde(rename = "type")]
+    pub relation_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueRelationCreateData {
+    pub issue_relation_create: IssueRelationPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueRelationPayload {
+    pub success: bool,
+    pub issue_relation: Option<IssueRelation>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IssueRelation {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub relation_type: String,
+}
+
 // --- Workflow states ---
 
 #[derive(Debug, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -402,6 +402,15 @@ impl RelationType {
             RelationType::Related => "related",
         }
     }
+
+    /// Human-readable summary of the created relation, for the success message.
+    pub fn summary(self, id: &str, related: &str) -> String {
+        match self {
+            RelationType::Blocks => format!("{id} now blocks {related}"),
+            RelationType::Duplicate => format!("{id} marked as a duplicate of {related}"),
+            RelationType::Related => format!("{id} now relates to {related}"),
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -1736,5 +1745,17 @@ mod tests {
         assert_eq!(RelationType::Blocks.as_api_str(), "blocks");
         assert_eq!(RelationType::Duplicate.as_api_str(), "duplicate");
         assert_eq!(RelationType::Related.as_api_str(), "related");
+    }
+
+    #[test]
+    fn relation_type_summary_reads_naturally() {
+        assert_eq!(
+            RelationType::Duplicate.summary("PLO-326", "PLO-351"),
+            "PLO-326 marked as a duplicate of PLO-351"
+        );
+        assert_eq!(
+            RelationType::Blocks.summary("A-1", "A-2"),
+            "A-1 now blocks A-2"
+        );
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -367,6 +367,41 @@ pub enum IssueCommand {
         #[arg(long)]
         parent: Option<String>,
     },
+    /// Link two issues with a relation (blocks, duplicate, or related)
+    Relation {
+        /// Issue identifier (e.g., ENG-123) or UUID
+        id: String,
+
+        /// Relation type: how `id` relates to `related`
+        relation_type: RelationType,
+
+        /// The related/target issue identifier (e.g., ENG-456) or UUID
+        related: String,
+    },
+}
+
+/// How one issue relates to another (`lin issue relation`).
+/// Values map to Linear's `IssueRelationType` GraphQL enum.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+#[value(rename_all = "lowercase")]
+pub enum RelationType {
+    /// `id` blocks `related`
+    Blocks,
+    /// `id` is a duplicate of `related`
+    Duplicate,
+    /// `id` is related to `related`
+    Related,
+}
+
+impl RelationType {
+    /// The Linear API enum value for this relation type.
+    pub fn as_api_str(self) -> &'static str {
+        match self {
+            RelationType::Blocks => "blocks",
+            RelationType::Duplicate => "duplicate",
+            RelationType::Related => "related",
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -1653,5 +1688,53 @@ mod tests {
             }
             _ => panic!("expected Download"),
         }
+    }
+
+    #[test]
+    fn issue_relation_duplicate_parses() {
+        let cli = parse(&[
+            "lin",
+            "issue",
+            "relation",
+            "PLO-326",
+            "duplicate",
+            "PLO-351",
+        ]);
+        match cli.command {
+            Commands::Issue(IssueCommand::Relation {
+                id,
+                relation_type,
+                related,
+            }) => {
+                assert_eq!(id, "PLO-326");
+                assert_eq!(relation_type, RelationType::Duplicate);
+                assert_eq!(related, "PLO-351");
+            }
+            _ => panic!("expected Issue Relation"),
+        }
+    }
+
+    #[test]
+    fn issue_relation_blocks_parses() {
+        let cli = parse(&["lin", "issue", "relation", "APP-12", "blocks", "APP-15"]);
+        match cli.command {
+            Commands::Issue(IssueCommand::Relation { relation_type, .. }) => {
+                assert_eq!(relation_type, RelationType::Blocks);
+            }
+            _ => panic!("expected Issue Relation"),
+        }
+    }
+
+    #[test]
+    fn issue_relation_rejects_unknown_type() {
+        let result = Cli::try_parse_from(["lin", "issue", "relation", "A-1", "mirrors", "A-2"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn relation_type_api_str_matches_linear_enum() {
+        assert_eq!(RelationType::Blocks.as_api_str(), "blocks");
+        assert_eq!(RelationType::Duplicate.as_api_str(), "duplicate");
+        assert_eq!(RelationType::Related.as_api_str(), "related");
     }
 }

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -6,6 +6,7 @@ use crate::api::queries::*;
 use crate::api::resolve;
 use crate::api::types::*;
 use crate::api::upload;
+use crate::cli::RelationType;
 use crate::date;
 use crate::output;
 
@@ -844,11 +845,10 @@ pub async fn state(
 }
 
 /// Create a relation (blocks / duplicate / related) from `id` to `related`.
-/// `relation_type` is the Linear API enum value ("blocks", "duplicate", "related").
 pub async fn relation(
     client: &LinearClient,
     id: &str,
-    relation_type: &str,
+    relation_type: RelationType,
     related: &str,
     json: bool,
 ) -> Result<()> {
@@ -858,7 +858,7 @@ pub async fn relation(
     let input = IssueRelationCreateInput {
         issue_id,
         related_issue_id,
-        relation_type: relation_type.to_string(),
+        relation_type: relation_type.as_api_str().to_string(),
     };
 
     let data: IssueRelationCreateData = client
@@ -869,7 +869,12 @@ pub async fn relation(
         .await?;
 
     if !data.issue_relation_create.success {
-        bail!("Failed to create issue relation");
+        bail!(
+            "Failed to create {} relation between {} and {}",
+            relation_type.as_api_str(),
+            id,
+            related
+        );
     }
 
     if json {
@@ -889,13 +894,7 @@ pub async fn relation(
         return Ok(());
     }
 
-    let summary = match relation_type {
-        "blocks" => format!("{} now blocks {}", id, related),
-        "duplicate" => format!("{} marked as a duplicate of {}", id, related),
-        "related" => format!("{} now relates to {}", id, related),
-        other => format!("{} linked to {} ({})", id, related, other),
-    };
-    output::print_success(&summary);
+    output::print_success(&relation_type.summary(id, related));
 
     Ok(())
 }

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -843,6 +843,63 @@ pub async fn state(
     Ok(())
 }
 
+/// Create a relation (blocks / duplicate / related) from `id` to `related`.
+/// `relation_type` is the Linear API enum value ("blocks", "duplicate", "related").
+pub async fn relation(
+    client: &LinearClient,
+    id: &str,
+    relation_type: &str,
+    related: &str,
+    json: bool,
+) -> Result<()> {
+    let issue_id = resolve::resolve_issue_identifier(client, id).await?;
+    let related_issue_id = resolve::resolve_issue_identifier(client, related).await?;
+
+    let input = IssueRelationCreateInput {
+        issue_id,
+        related_issue_id,
+        relation_type: relation_type.to_string(),
+    };
+
+    let data: IssueRelationCreateData = client
+        .execute(
+            ISSUE_RELATION_CREATE_MUTATION,
+            Some(json!({ "input": input })),
+        )
+        .await?;
+
+    if !data.issue_relation_create.success {
+        bail!("Failed to create issue relation");
+    }
+
+    if json {
+        match data.issue_relation_create.issue_relation.as_ref() {
+            Some(rel) => output::print_json(&json!({
+                "success": true,
+                "relation": { "id": rel.id, "type": rel.relation_type },
+                "issue": id,
+                "relatedIssue": related,
+            })),
+            None => output::print_json(&json!({
+                "success": true,
+                "issue": id,
+                "relatedIssue": related,
+            })),
+        }
+        return Ok(());
+    }
+
+    let summary = match relation_type {
+        "blocks" => format!("{} now blocks {}", id, related),
+        "duplicate" => format!("{} marked as a duplicate of {}", id, related),
+        "related" => format!("{} now relates to {}", id, related),
+        other => format!("{} linked to {} ({})", id, related, other),
+    };
+    output::print_success(&summary);
+
+    Ok(())
+}
+
 pub async fn attachment_add(
     client: &LinearClient,
     id: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,14 +276,8 @@ async fn run(cli: Cli) -> Result<()> {
                     relation_type,
                     related,
                 } => {
-                    commands::issue::relation(
-                        &ctx.client,
-                        &id,
-                        relation_type.as_api_str(),
-                        &related,
-                        ctx.json,
-                    )
-                    .await?;
+                    commands::issue::relation(&ctx.client, &id, relation_type, &related, ctx.json)
+                        .await?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,6 +271,20 @@ async fn run(cli: Cli) -> Result<()> {
                     )
                     .await?;
                 }
+                IssueCommand::Relation {
+                    id,
+                    relation_type,
+                    related,
+                } => {
+                    commands::issue::relation(
+                        &ctx.client,
+                        &id,
+                        relation_type.as_api_str(),
+                        &related,
+                        ctx.json,
+                    )
+                    .await?;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Adds `lin issue relation`, a command to create relations between issues via Linear's `issueRelationCreate` mutation. Closes #46.

```sh
lin issue relation PLO-326 duplicate PLO-351   # PLO-326 is a duplicate of PLO-351
lin issue relation APP-12  blocks     APP-15   # APP-12 blocks APP-15
lin issue relation ENG-1   related    ENG-2    # ENG-1 relates to ENG-2
```

Both issue arguments accept identifiers (e.g. `APP-123`) or UUIDs and are resolved through the existing `resolve_issue_identifier` helper. `--json` prints the created relation for scripting.

## Why

There was no CLI primitive for issue relations. The most visible gap: you can't mark an issue as a duplicate, because Linear rejects the `Duplicate` workflow state unless a duplicate **relation** already exists:

```
$ lin issue edit PLO-326 --state "Duplicate"
error: GraphQL errors: missing duplicate relation
```

`issue relation … duplicate …` establishes that relation, which also unblocks the `Duplicate` state path.

## Changes

- `cli.rs`: new `IssueCommand::Relation` variant + a `RelationType` value enum (`blocks` / `duplicate` / `related`) mapping to Linear's `IssueRelationType`.
- `api/queries.rs`: `ISSUE_RELATION_CREATE_MUTATION`.
- `api/types.rs`: `IssueRelationCreateInput` / `IssueRelationCreateData` / `IssueRelationPayload` / `IssueRelation`.
- `commands/issue.rs`: `relation()` handler — resolves both identifiers, creates the relation, prints a human summary (or JSON with `--json`).
- `main.rs`: dispatch wiring.
- README + CHANGELOG.

## Scope

Relation **create** only (blocks / duplicate / related). Listing and removing relations are natural follow-ups.

## Testing

- 4 new parse/unit tests; full suite green (`cargo test` — 100 passed, 0 failed).
- `cargo fmt --check` and `cargo clippy --all-targets` both clean.
- Manually verified `--help` output and that invalid relation types are rejected with `[possible values: blocks, duplicate, related]`.
