### PR TITLE
feat: label edit/delete, issue relations, and raw GraphQL commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `issue relate <id> --to <id>` command to link two issues via Linear's `issueRelationCreate` mutation, with `--type blocks|blocked-by|related|duplicate` (default `related`); `blocked-by` is sugar for a `blocks` relation with the issues swapped
+- `issue relations <id>` command to list an issue's outgoing and incoming relations (including the relation IDs needed to remove them)
+- `issue unrelate <relation-id>` command to remove a relation via Linear's `issueRelationDelete` mutation
+- `lin gql <query>` command to run a raw GraphQL query or mutation against the Linear API; the document and `--variables` each accept a literal string, `@file`, or `-` for stdin
 - `label edit <name|uuid>` command with `--name`, `--color`, `--description`, and `--parent-id` flags for updating a label via Linear's `issueLabelUpdate` mutation
 - `label delete <name|uuid>` command for removing a label via Linear's `issueLabelDelete` mutation
 - `label edit`/`label delete` resolve an ambiguous label name (the same name used across multiple teams) by erroring with the list of teams instead of mutating an arbitrary match; pass `--team <name|key|uuid>` to scope the lookup to one team

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `label edit <name|uuid>` command with `--name`, `--color`, `--description`, and `--parent-id` flags for updating a label via Linear's `issueLabelUpdate` mutation
 - `label delete <name|uuid>` command for removing a label via Linear's `issueLabelDelete` mutation
+- `label edit`/`label delete` resolve an ambiguous label name (the same name used across multiple teams) by erroring with the list of teams instead of mutating an arbitrary match; pass `--team <name|key|uuid>` to scope the lookup to one team
 - `cycle edit` command with `--name`, `--description`, `--starts`, and `--ends` flags for updating cycle properties
 - `lin download <URL>` command to download files directly from `uploads.linear.app` URLs without needing the parent issue
 - `comment add --parent <comment-id>` and `issue comment --parent <comment-id>` flags to nest a reply under an existing comment via Linear's `commentCreate` `parentId` input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `label edit <name|uuid>` command with `--name`, `--color`, `--description`, and `--parent-id` flags for updating a label via Linear's `issueLabelUpdate` mutation
+- `label delete <name|uuid>` command for removing a label via Linear's `issueLabelDelete` mutation
 - `cycle edit` command with `--name`, `--description`, `--starts`, and `--ends` flags for updating cycle properties
 - `lin download <URL>` command to download files directly from `uploads.linear.app` URLs without needing the parent issue
 - `comment add --parent <comment-id>` and `issue comment --parent <comment-id>` flags to nest a reply under an existing comment via Linear's `commentCreate` `parentId` input

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ lin issue attachments list ENG-123
 lin issue attachments add ENG-123 screenshot.png
 lin issue attachments download ENG-123 -o /tmp/
 lin issue attachments download ENG-123 --attachment-id f17b -o /tmp/
+lin issue relate ENG-123 --to ENG-456                 # related (default)
+lin issue relate ENG-123 --to ENG-456 --type blocks   # ENG-123 blocks ENG-456
+lin issue relate ENG-123 --to ENG-456 --type blocked-by
+lin issue relate ENG-123 --to ENG-456 --type duplicate
+lin issue relations ENG-123
+lin issue unrelate <relation-id>                      # id from `lin issue relations`
 ```
 
 ### Comments
@@ -142,6 +148,24 @@ lin label create "Bug" --team APP
 lin workspace current
 lin workspace list
 lin workspace set my-workspace
+```
+
+### Raw GraphQL
+
+For anything the dedicated commands don't cover, `lin gql` runs a raw query or
+mutation against the Linear API using your stored token. Output is always JSON.
+
+```sh
+# Inline query
+lin gql 'query { viewer { id name email } }'
+
+# With variables (JSON object)
+lin gql 'query($id: String!) { issue(id: $id) { identifier title } }' \
+  --variables '{"id": "ENG-123"}'
+
+# Read the document from a file, or - for stdin
+lin gql @query.graphql --variables @vars.json
+cat query.graphql | lin gql -
 ```
 
 ### Identifier Resolution

--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -349,6 +349,27 @@ pub const LABEL_CREATE_MUTATION: &str = r#"
     }
 "#;
 
+pub const LABEL_UPDATE_MUTATION: &str = r#"
+    mutation IssueLabelUpdate($id: String!, $input: IssueLabelUpdateInput!) {
+        issueLabelUpdate(id: $id, input: $input) {
+            success
+            issueLabel {
+                id
+                name
+                color
+            }
+        }
+    }
+"#;
+
+pub const LABEL_DELETE_MUTATION: &str = r#"
+    mutation IssueLabelDelete($id: String!) {
+        issueLabelDelete(id: $id) {
+            success
+        }
+    }
+"#;
+
 // --- File Attachments ---
 
 pub const FILE_UPLOAD_MUTATION: &str = r#"

--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -99,6 +99,52 @@ pub const ISSUE_UPDATE_MUTATION: &str = r#"
     }
 "#;
 
+pub const ISSUE_RELATIONS_QUERY: &str = r#"
+    query IssueRelations($id: String!) {
+        issue(id: $id) {
+            id
+            identifier
+            title
+            relations {
+                nodes {
+                    id
+                    type
+                    relatedIssue { identifier title }
+                }
+            }
+            inverseRelations {
+                nodes {
+                    id
+                    type
+                    issue { identifier title }
+                }
+            }
+        }
+    }
+"#;
+
+pub const ISSUE_RELATION_CREATE_MUTATION: &str = r#"
+    mutation IssueRelationCreate($input: IssueRelationCreateInput!) {
+        issueRelationCreate(input: $input) {
+            success
+            issueRelation {
+                id
+                type
+                issue { identifier title }
+                relatedIssue { identifier title }
+            }
+        }
+    }
+"#;
+
+pub const ISSUE_RELATION_DELETE_MUTATION: &str = r#"
+    mutation IssueRelationDelete($id: String!) {
+        issueRelationDelete(id: $id) {
+            success
+        }
+    }
+"#;
+
 pub const TEAM_STATES_QUERY: &str = r#"
     query Team($id: String!) {
         team(id: $id) {

--- a/src/api/queries.rs
+++ b/src/api/queries.rs
@@ -327,6 +327,10 @@ pub const LABELS_QUERY: &str = r#"
                 id
                 name
                 color
+                team {
+                    key
+                    name
+                }
             }
             pageInfo {
                 hasNextPage

--- a/src/api/resolve.rs
+++ b/src/api/resolve.rs
@@ -245,14 +245,32 @@ pub async fn resolve_cycle_identifier(
 }
 
 /// Resolve a single label identifier (name or UUID) to a UUID.
-/// If already a UUID, returns as-is.
+///
+/// Tries a case-insensitive name match first, since label names are free-text
+/// and can themselves look like a UUID to `is_uuid` (e.g. a long hyphenated
+/// name). Only when no name matches do we fall back to treating the input as a
+/// raw UUID, so a genuine ID still works without a wasted error.
 pub async fn resolve_label_identifier(client: &LinearClient, identifier: &str) -> Result<String> {
+    let all_labels = fetch_all_labels(client, None).await?;
+
+    let lower = identifier.to_lowercase();
+    if let Some(label) = all_labels.iter().find(|l| l.name.to_lowercase() == lower) {
+        return Ok(label.id.clone());
+    }
+
     if is_uuid(identifier) {
         return Ok(identifier.to_string());
     }
 
-    let ids = resolve_label_names(client, std::slice::from_ref(&identifier.to_string())).await?;
-    Ok(ids.into_iter().next().expect("resolved one label id"))
+    bail!(
+        "Label '{}' not found. Available labels: {}",
+        identifier,
+        all_labels
+            .iter()
+            .map(|l| l.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 /// Resolve label names to label IDs via case-insensitive matching.
@@ -313,4 +331,29 @@ pub async fn fetch_all_labels(
     }
 
     Ok(all_labels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_uuid;
+
+    #[test]
+    fn detects_real_uuids() {
+        assert!(is_uuid("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+    }
+
+    #[test]
+    fn rejects_short_or_plain_strings() {
+        assert!(!is_uuid("bug"));
+        assert!(!is_uuid("needs review")); // spaces, no dash
+        assert!(!is_uuid("good-first-issue")); // has dash but under the length cutoff
+    }
+
+    #[test]
+    fn long_hyphenated_label_name_looks_like_a_uuid() {
+        // The heuristic can't tell this free-text label name from a UUID, which
+        // is exactly why `resolve_label_identifier` matches by name first and
+        // only falls back to treating the input as a raw id.
+        assert!(is_uuid("needs-more-information-before-triage"));
+    }
 }

--- a/src/api/resolve.rs
+++ b/src/api/resolve.rs
@@ -244,6 +244,17 @@ pub async fn resolve_cycle_identifier(
     }
 }
 
+/// Resolve a single label identifier (name or UUID) to a UUID.
+/// If already a UUID, returns as-is.
+pub async fn resolve_label_identifier(client: &LinearClient, identifier: &str) -> Result<String> {
+    if is_uuid(identifier) {
+        return Ok(identifier.to_string());
+    }
+
+    let ids = resolve_label_names(client, std::slice::from_ref(&identifier.to_string())).await?;
+    Ok(ids.into_iter().next().expect("resolved one label id"))
+}
+
 /// Resolve label names to label IDs via case-insensitive matching.
 /// Paginates through all workspace labels to avoid missing any.
 pub async fn resolve_label_names(client: &LinearClient, names: &[String]) -> Result<Vec<String>> {

--- a/src/api/resolve.rs
+++ b/src/api/resolve.rs
@@ -250,12 +250,50 @@ pub async fn resolve_cycle_identifier(
 /// and can themselves look like a UUID to `is_uuid` (e.g. a long hyphenated
 /// name). Only when no name matches do we fall back to treating the input as a
 /// raw UUID, so a genuine ID still works without a wasted error.
-pub async fn resolve_label_identifier(client: &LinearClient, identifier: &str) -> Result<String> {
-    let all_labels = fetch_all_labels(client, None).await?;
+///
+/// Linear allows the same label name in multiple teams, so a bare name can be
+/// ambiguous. When more than one label matches we bail rather than pick an
+/// arbitrary one — important because callers like `label delete` are
+/// destructive. Pass `team` to scope the search to a single team and
+/// disambiguate.
+pub async fn resolve_label_identifier(
+    client: &LinearClient,
+    identifier: &str,
+    team: Option<&str>,
+) -> Result<String> {
+    let filter = match team {
+        Some(t) => {
+            let team_id = resolve_team_identifier(client, t).await?;
+            Some(json!({ "team": { "id": { "eq": team_id } } }))
+        }
+        None => None,
+    };
+
+    let all_labels = fetch_all_labels(client, filter).await?;
 
     let lower = identifier.to_lowercase();
-    if let Some(label) = all_labels.iter().find(|l| l.name.to_lowercase() == lower) {
-        return Ok(label.id.clone());
+    let matches: Vec<&Label> = all_labels
+        .iter()
+        .filter(|l| l.name.to_lowercase() == lower)
+        .collect();
+
+    match matches.as_slice() {
+        [label] => return Ok(label.id.clone()),
+        [_, ..] => bail!(
+            "Label '{}' is ambiguous — {} labels share that name across teams: {}. \
+             Re-run with --team to choose one, or pass the label's UUID.",
+            identifier,
+            matches.len(),
+            matches
+                .iter()
+                .map(|l| match &l.team {
+                    Some(t) => t.key.clone().unwrap_or_else(|| t.name.clone()),
+                    None => "(workspace)".to_string(),
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        [] => {}
     }
 
     if is_uuid(identifier) {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -439,6 +439,18 @@ pub struct LabelCreateData {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct LabelUpdateData {
+    pub issue_label_update: LabelPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelDeleteData {
+    pub issue_label_delete: DeletePayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LabelPayload {
     pub success: bool,
     pub issue_label: Option<Label>,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -167,6 +167,57 @@ pub struct IssueUpdateData {
     pub issue_update: IssuePayload,
 }
 
+// --- Issue relations ---
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueRelation {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub relation_type: String,
+    pub issue: Option<RelationIssueRef>,
+    pub related_issue: Option<RelationIssueRef>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RelationIssueRef {
+    pub identifier: String,
+    pub title: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueWithRelations {
+    pub identifier: String,
+    pub title: String,
+    pub relations: Connection<IssueRelation>,
+    pub inverse_relations: Connection<IssueRelation>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IssueRelationsData {
+    pub issue: IssueWithRelations,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueRelationCreateData {
+    pub issue_relation_create: IssueRelationPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueRelationPayload {
+    pub success: bool,
+    pub issue_relation: Option<IssueRelation>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueRelationDeleteData {
+    pub issue_relation_delete: DeletePayload,
+}
+
 // --- Workflow states ---
 
 #[derive(Debug, Deserialize)]

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -50,6 +50,14 @@ pub struct Label {
     pub id: String,
     pub name: String,
     pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team: Option<LabelTeam>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LabelTeam {
+    pub key: Option<String>,
+    pub name: String,
 }
 
 // --- WorkflowState ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -625,6 +625,32 @@ pub enum LabelCommand {
         #[arg(long)]
         parent_id: Option<String>,
     },
+    /// Edit a label
+    Edit {
+        /// Label name or UUID
+        label: String,
+
+        /// New label name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Label color (hex, e.g., #ff0000)
+        #[arg(long)]
+        color: Option<String>,
+
+        /// Label description
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Parent label ID
+        #[arg(long)]
+        parent_id: Option<String>,
+    },
+    /// Delete a label
+    Delete {
+        /// Label name or UUID
+        label: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -630,6 +630,10 @@ pub enum LabelCommand {
         /// Label name or UUID
         label: String,
 
+        /// Scope the label lookup to a team (name, key, or UUID) to disambiguate names
+        #[arg(long)]
+        team: Option<String>,
+
         /// New label name
         #[arg(long)]
         name: Option<String>,
@@ -650,6 +654,10 @@ pub enum LabelCommand {
     Delete {
         /// Label name or UUID
         label: String,
+
+        /// Scope the label lookup to a team (name, key, or UUID) to disambiguate names
+        #[arg(long)]
+        team: Option<String>,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,30 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+
+/// How one issue relates to another.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum RelationType {
+    /// This issue blocks the other
+    Blocks,
+    /// This issue is blocked by the other
+    BlockedBy,
+    /// The two issues are related
+    Related,
+    /// This issue is a duplicate of the other
+    Duplicate,
+}
+
+impl RelationType {
+    /// Map the relation to the (source, target, api_type) the Linear API expects.
+    /// `blocked-by` is sugar for a `blocks` relation with the issues swapped.
+    pub fn resolve<'a>(&self, id: &'a str, to: &'a str) -> (&'a str, &'a str, &'static str) {
+        match self {
+            RelationType::Blocks => (id, to, "blocks"),
+            RelationType::BlockedBy => (to, id, "blocks"),
+            RelationType::Related => (id, to, "related"),
+            RelationType::Duplicate => (id, to, "duplicate"),
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(name = "lin", about = "A fast CLI for Linear", version)]
@@ -80,6 +106,16 @@ pub enum Commands {
         /// Output directory (defaults to current directory)
         #[arg(long, short, default_value = ".")]
         output: String,
+    },
+
+    /// Run a raw GraphQL query or mutation against the Linear API
+    Gql {
+        /// GraphQL document: a literal string, @file to read from a file, or - for stdin
+        query: String,
+
+        /// Variables as a JSON object: a literal string, @file, or - for stdin
+        #[arg(long)]
+        variables: Option<String>,
     },
 
     /// View changelog
@@ -366,6 +402,29 @@ pub enum IssueCommand {
         /// Reply under an existing comment (parent comment UUID)
         #[arg(long)]
         parent: Option<String>,
+    },
+    /// Link this issue to another (blocks, blocked-by, related, duplicate)
+    Relate {
+        /// Issue identifier (e.g., ENG-123) or UUID
+        id: String,
+
+        /// The other issue identifier or UUID
+        #[arg(long)]
+        to: String,
+
+        /// Relation type
+        #[arg(long = "type", value_enum, default_value_t = RelationType::Related)]
+        relation_type: RelationType,
+    },
+    /// List an issue's relations
+    Relations {
+        /// Issue identifier (e.g., ENG-123) or UUID
+        id: String,
+    },
+    /// Remove an issue relation by its ID (from `lin issue relations`)
+    Unrelate {
+        /// Relation UUID
+        relation_id: String,
     },
 }
 

--- a/src/commands/gql.rs
+++ b/src/commands/gql.rs
@@ -1,0 +1,42 @@
+use std::io::Read;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::api::client::LinearClient;
+use crate::output;
+
+/// Read an argument that may be a literal string, `@path` to read from a file,
+/// or `-` to read from stdin.
+fn read_source(arg: &str, what: &str) -> Result<String> {
+    if arg == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .with_context(|| format!("Failed to read {what} from stdin"))?;
+        Ok(buf)
+    } else if let Some(path) = arg.strip_prefix('@') {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {what} from file: {path}"))
+    } else {
+        Ok(arg.to_string())
+    }
+}
+
+pub async fn run(client: &LinearClient, query: &str, variables: Option<&str>) -> Result<()> {
+    let document = read_source(query, "query")?;
+
+    let vars: Option<Value> = match variables {
+        Some(v) => {
+            let raw = read_source(v, "variables")?;
+            let parsed: Value =
+                serde_json::from_str(&raw).context("Variables must be a valid JSON object")?;
+            Some(parsed)
+        }
+        None => None,
+    };
+
+    let data = client.execute_raw(&document, vars).await?;
+    output::print_json(&data);
+    Ok(())
+}

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -359,7 +359,6 @@ pub async fn edit(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 /// Create a relation between two issues. `source`, `target`, and `api_type`
 /// are already resolved by the caller (see `RelationType::resolve`).
 pub async fn relate(
@@ -479,6 +478,7 @@ pub async fn unrelate(client: &LinearClient, relation_id: &str) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn search(
     client: &LinearClient,
     query: &str,

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -360,6 +360,125 @@ pub async fn edit(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Create a relation between two issues. `source`, `target`, and `api_type`
+/// are already resolved by the caller (see `RelationType::resolve`).
+pub async fn relate(
+    client: &LinearClient,
+    source: &str,
+    target: &str,
+    api_type: &str,
+) -> Result<()> {
+    let source_id = resolve::resolve_issue_identifier(client, source).await?;
+    let target_id = resolve::resolve_issue_identifier(client, target).await?;
+
+    let input = json!({
+        "issueId": source_id,
+        "relatedIssueId": target_id,
+        "type": api_type,
+    });
+
+    let data: IssueRelationCreateData = client
+        .execute(
+            ISSUE_RELATION_CREATE_MUTATION,
+            Some(json!({ "input": input })),
+        )
+        .await?;
+
+    if !data.issue_relation_create.success {
+        bail!("Failed to create relation");
+    }
+
+    if let Some(rel) = data.issue_relation_create.issue_relation {
+        let from = rel
+            .issue
+            .as_ref()
+            .map(|i| i.identifier.as_str())
+            .unwrap_or("?");
+        let to = rel
+            .related_issue
+            .as_ref()
+            .map(|i| i.identifier.as_str())
+            .unwrap_or("?");
+        output::print_success(&format!("Linked {} → {} ({})", from, to, rel.relation_type));
+    }
+
+    Ok(())
+}
+
+pub async fn relations(client: &LinearClient, id: &str, json_output: bool) -> Result<()> {
+    if json_output {
+        let data = client
+            .execute_raw(ISSUE_RELATIONS_QUERY, Some(json!({ "id": id })))
+            .await?;
+        output::print_json(&data);
+        return Ok(());
+    }
+
+    let data: IssueRelationsData = client
+        .execute(ISSUE_RELATIONS_QUERY, Some(json!({ "id": id })))
+        .await?;
+    let issue = data.issue;
+
+    output::print_header(&format!(
+        "{} — {} · relations",
+        issue.identifier, issue.title
+    ));
+
+    let mut any = false;
+
+    // Relations defined on this issue (this issue is the source).
+    for rel in &issue.relations.nodes {
+        let label = match rel.relation_type.as_str() {
+            "blocks" => "Blocks",
+            "related" => "Related to",
+            "duplicate" => "Duplicate of",
+            "similar" => "Similar to",
+            other => other,
+        };
+        if let Some(o) = rel.related_issue.as_ref() {
+            println!("  {} {} — {}  ({})", label, o.identifier, o.title, rel.id);
+            any = true;
+        }
+    }
+
+    // Relations pointing at this issue (this issue is the target).
+    for rel in &issue.inverse_relations.nodes {
+        let label = match rel.relation_type.as_str() {
+            "blocks" => "Blocked by",
+            "related" => "Related to",
+            "duplicate" => "Duplicated by",
+            "similar" => "Similar to",
+            other => other,
+        };
+        if let Some(o) = rel.issue.as_ref() {
+            println!("  {} {} — {}  ({})", label, o.identifier, o.title, rel.id);
+            any = true;
+        }
+    }
+
+    if !any {
+        println!("  (no relations)");
+    }
+
+    Ok(())
+}
+
+pub async fn unrelate(client: &LinearClient, relation_id: &str) -> Result<()> {
+    let data: IssueRelationDeleteData = client
+        .execute(
+            ISSUE_RELATION_DELETE_MUTATION,
+            Some(json!({ "id": relation_id })),
+        )
+        .await?;
+
+    if !data.issue_relation_delete.success {
+        bail!("Failed to delete relation");
+    }
+
+    output::print_success(&format!("Removed relation {}", relation_id));
+    Ok(())
+}
+
 pub async fn search(
     client: &LinearClient,
     query: &str,

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -88,7 +88,9 @@ pub async fn edit(
     parent_id: Option<&str>,
 ) -> Result<()> {
     if name.is_none() && color.is_none() && description.is_none() && parent_id.is_none() {
-        bail!("Nothing to update. Provide at least one of --name, --color, --description, --parent-id");
+        bail!(
+            "Nothing to update. Provide at least one of --name, --color, --description, --parent-id"
+        );
     }
 
     let label_id = resolve::resolve_label_identifier(client, label, team).await?;

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -77,3 +77,64 @@ pub async fn create(
 
     Ok(())
 }
+
+pub async fn edit(
+    client: &LinearClient,
+    label: &str,
+    name: Option<&str>,
+    color: Option<&str>,
+    description: Option<&str>,
+    parent_id: Option<&str>,
+) -> Result<()> {
+    if name.is_none() && color.is_none() && description.is_none() && parent_id.is_none() {
+        bail!("Nothing to update. Provide at least one of --name, --color, --description, --parent-id");
+    }
+
+    let label_id = resolve::resolve_label_identifier(client, label).await?;
+    let mut input = json!({});
+
+    if let Some(n) = name {
+        input["name"] = json!(n);
+    }
+    if let Some(c) = color {
+        input["color"] = json!(c);
+    }
+    if let Some(d) = description {
+        input["description"] = json!(d);
+    }
+    if let Some(p) = parent_id {
+        input["parentId"] = json!(p);
+    }
+
+    let data: LabelUpdateData = client
+        .execute(
+            LABEL_UPDATE_MUTATION,
+            Some(json!({ "id": label_id, "input": input })),
+        )
+        .await?;
+
+    if !data.issue_label_update.success {
+        bail!("Failed to update label");
+    }
+
+    if let Some(label) = data.issue_label_update.issue_label {
+        output::print_success(&format!("Updated label: {}", label.name));
+    }
+
+    Ok(())
+}
+
+pub async fn delete(client: &LinearClient, label: &str) -> Result<()> {
+    let label_id = resolve::resolve_label_identifier(client, label).await?;
+
+    let data: LabelDeleteData = client
+        .execute(LABEL_DELETE_MUTATION, Some(json!({ "id": label_id })))
+        .await?;
+
+    if !data.issue_label_delete.success {
+        bail!("Failed to delete label");
+    }
+
+    output::print_success(&format!("Deleted label: {}", label));
+    Ok(())
+}

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -81,6 +81,7 @@ pub async fn create(
 pub async fn edit(
     client: &LinearClient,
     label: &str,
+    team: Option<&str>,
     name: Option<&str>,
     color: Option<&str>,
     description: Option<&str>,
@@ -90,7 +91,7 @@ pub async fn edit(
         bail!("Nothing to update. Provide at least one of --name, --color, --description, --parent-id");
     }
 
-    let label_id = resolve::resolve_label_identifier(client, label).await?;
+    let label_id = resolve::resolve_label_identifier(client, label, team).await?;
     let mut input = json!({});
 
     if let Some(n) = name {
@@ -124,8 +125,8 @@ pub async fn edit(
     Ok(())
 }
 
-pub async fn delete(client: &LinearClient, label: &str) -> Result<()> {
-    let label_id = resolve::resolve_label_identifier(client, label).await?;
+pub async fn delete(client: &LinearClient, label: &str, team: Option<&str>) -> Result<()> {
+    let label_id = resolve::resolve_label_identifier(client, label, team).await?;
 
     let data: LabelDeleteData = client
         .execute(LABEL_DELETE_MUTATION, Some(json!({ "id": label_id })))

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod changelog;
 pub mod comment;
 pub mod cycle;
 pub mod download;
+pub mod gql;
 pub mod initiative;
 pub mod issue;
 pub mod label;

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,6 +271,20 @@ async fn run(cli: Cli) -> Result<()> {
                     )
                     .await?;
                 }
+                IssueCommand::Relate {
+                    id,
+                    to,
+                    relation_type,
+                } => {
+                    let (source, target, api_type) = relation_type.resolve(&id, &to);
+                    commands::issue::relate(&ctx.client, source, target, api_type).await?;
+                }
+                IssueCommand::Relations { id } => {
+                    commands::issue::relations(&ctx.client, &id, ctx.json).await?;
+                }
+                IssueCommand::Unrelate { relation_id } => {
+                    commands::issue::unrelate(&ctx.client, &relation_id).await?;
+                }
             }
         }
 
@@ -531,6 +545,11 @@ async fn run(cli: Cli) -> Result<()> {
             let ws = workspace::resolve_workspace(ws_flag);
             let token = auth::get_token(&ws)?;
             commands::download::run(&token, &url, &output).await?;
+        }
+
+        Commands::Gql { query, variables } => {
+            let ctx = ensure_auth(ws_flag, json, verbose)?;
+            commands::gql::run(&ctx.client, &query, variables.as_deref()).await?;
         }
 
         Commands::Changelog => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -437,6 +437,7 @@ async fn run(cli: Cli) -> Result<()> {
                 }
                 LabelCommand::Edit {
                     label,
+                    team,
                     name,
                     color,
                     description,
@@ -445,6 +446,7 @@ async fn run(cli: Cli) -> Result<()> {
                     commands::label::edit(
                         &ctx.client,
                         &label,
+                        team.as_deref(),
                         name.as_deref(),
                         color.as_deref(),
                         description.as_deref(),
@@ -452,8 +454,8 @@ async fn run(cli: Cli) -> Result<()> {
                     )
                     .await?;
                 }
-                LabelCommand::Delete { label } => {
-                    commands::label::delete(&ctx.client, &label).await?;
+                LabelCommand::Delete { label, team } => {
+                    commands::label::delete(&ctx.client, &label, team.as_deref()).await?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,6 +435,26 @@ async fn run(cli: Cli) -> Result<()> {
                     )
                     .await?;
                 }
+                LabelCommand::Edit {
+                    label,
+                    name,
+                    color,
+                    description,
+                    parent_id,
+                } => {
+                    commands::label::edit(
+                        &ctx.client,
+                        &label,
+                        name.as_deref(),
+                        color.as_deref(),
+                        description.as_deref(),
+                        parent_id.as_deref(),
+                    )
+                    .await?;
+                }
+                LabelCommand::Delete { label } => {
+                    commands::label::delete(&ctx.client, &label).await?;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Bundles three additions to the `lin` CLI. (Supersedes #45, which contained the label commits; this PR carries those plus issue relations and a raw GraphQL escape hatch.)

### Label edit / delete
- `lin label edit <name|uuid>` with `--name`, `--color`, `--description`, `--parent-id` (Linear `issueLabelUpdate`).
- `lin label delete <name|uuid>` (Linear `issueLabelDelete`).
- Both resolve a label by name first, falling back to a raw UUID. An ambiguous name (same name across multiple teams) errors with the list of teams instead of mutating an arbitrary match; scope with `--team <name|key|uuid>`.

### Issue relations
Wraps Linear's `issueRelationCreate` / `issueRelationDelete` and the `issue.relations` / `inverseRelations` connections.
- `lin issue relate <id> --to <id> [--type blocks|blocked-by|related|duplicate]` — default `related`. `blocked-by` is sugar for a `blocks` relation with the two issues swapped.
- `lin issue relations <id>` — lists outgoing and incoming relations, each with the relation ID needed to remove it.
- `lin issue unrelate <relation-id>` — removes a relation by ID.

Issue arguments accept identifiers (`ENG-123`) or UUIDs, resolved via the existing `resolve_issue_identifier`.

### Raw GraphQL escape hatch
- `lin gql <query> [--variables <json>]` — runs an arbitrary query or mutation using the stored token. The document and `--variables` each accept a literal string, `@file`, or `-` for stdin. Output is always JSON.

## Implementation
Follows the existing vertical-slice pattern: GraphQL consts in `api/queries.rs`, response/payload structs in `api/types.rs`, clap variants (+ a `RelationType` enum with a `resolve()` helper for the blocked-by swap) in `cli.rs`, handlers in `commands/{label,issue,gql}.rs`, dispatch in `main.rs`.

## Testing
`cargo build`, `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` (95 pass) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)