### PR TITLE
feat: add `--due-date` flag to `issue create`/`issue edit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `comment reply <comment-id> <body>` subcommand that looks up the parent comment's issue automatically, so replies only need the parent comment UUID
 - `project create` and `project edit` `--start` and `--target` (alias `--end`) flags for setting project start and target dates (accepts `YYYY-MM-DD` or relative shorthand like `3d`, `1w`)
 - `issue list` JSON output now includes the `cycle` field (id, number, name) for each issue
-- `issue create` and `issue edit` `--due-date` (alias `--due`) flag for setting an issue's due date via Linear's `dueDate` input; accepts `YYYY-MM-DD` or relative shorthand like `3d`, `1w`, which counts **forward** from today (unlike the `--due-after`/`--due-before` list filters, where `3d` means three days ago)
+- `issue create` and `issue edit` `--due-date` (alias `--due`) flag for setting an issue's due date via Linear's `dueDate` input; accepts `YYYY-MM-DD` or relative shorthand like `0d` (today), `3d`, `1w`, which counts **forward** from the local day (unlike the `--due-after`/`--due-before` list filters, where `3d` means three days ago). Note `1m` is 30 days, not a calendar month
+- `issue edit --clear-due-date` to remove an issue's due date; rejected if combined with `--due-date`
 
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `comment reply <comment-id> <body>` subcommand that looks up the parent comment's issue automatically, so replies only need the parent comment UUID
 - `project create` and `project edit` `--start` and `--target` (alias `--end`) flags for setting project start and target dates (accepts `YYYY-MM-DD` or relative shorthand like `3d`, `1w`)
 - `issue list` JSON output now includes the `cycle` field (id, number, name) for each issue
+- `issue create` and `issue edit` `--due-date` (alias `--due`) flag for setting an issue's due date via Linear's `dueDate` input; accepts `YYYY-MM-DD` or relative shorthand like `3d`, `1w`, which counts **forward** from today (unlike the `--due-after`/`--due-before` list filters, where `3d` means three days ago)
 
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,7 +1413,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ keyring = { version = "3", features = ["apple-native", "linux-native"] }
 thiserror = "2"
 anyhow = "1"
 colored = "3"
-time = { version = "0.3", features = ["formatting", "parsing"] }
+time = { version = "0.3", features = ["formatting", "parsing", "local-offset"] }
 dirs = "6"

--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ lin issue me --status "Todo"
 lin issue create "Fix login" --team APP
 lin issue create "Fix login" --team APP --assignee me --priority 2
 lin issue create "Sprint task" --team APP --cycle current
+lin issue create "Ship v2" --team APP --due-date 2026-09-30
 lin issue edit ENG-123 --state "In Progress"
 lin issue edit ENG-123 --cycle 42
+lin issue edit ENG-123 --due-date 2026-09-30
+lin issue edit ENG-123 --due 1w              # one week from today
 lin issue state ENG-123
 lin issue state ENG-123 "Done"
 lin issue state ENG-123 --list

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ lin issue create "Ship v2" --team APP --due-date 2026-09-30
 lin issue edit ENG-123 --state "In Progress"
 lin issue edit ENG-123 --cycle 42
 lin issue edit ENG-123 --due-date 2026-09-30
-lin issue edit ENG-123 --due 1w              # one week from today
+lin issue edit ENG-123 --due 1w              # one week from today (local)
+lin issue edit ENG-123 --due 0d              # today
+lin issue edit ENG-123 --clear-due-date
 lin issue state ENG-123
 lin issue state ENG-123 "Done"
 lin issue state ENG-123 --list

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -611,8 +611,10 @@ pub struct IssueUpdateInput {
     pub parent_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cycle_id: Option<String>,
+    /// `None` leaves the due date alone; `Some(Null)` clears it, which is why
+    /// this is a `Value` rather than a `String` like the other fields.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub due_date: Option<String>,
+    pub due_date: Option<serde_json::Value>,
 }
 
 // --- Cycles ---

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -252,6 +252,8 @@ pub struct IssueCreateInput {
     pub parent_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cycle_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub due_date: Option<String>,
 }
 
 // --- Comment ---
@@ -609,6 +611,8 @@ pub struct IssueUpdateInput {
     pub parent_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cycle_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub due_date: Option<String>,
 }
 
 // --- Cycles ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -171,7 +171,7 @@ pub enum IssueCommand {
         #[arg(long)]
         cycle: Option<String>,
 
-        /// Due date (YYYY-MM-DD, or relative like 3d, 1w counting forward from today)
+        /// Due date (YYYY-MM-DD, or relative like 0d, 3d, 1w counting forward from today; 1m is 30 days)
         #[arg(long, alias = "due")]
         due_date: Option<String>,
 
@@ -228,9 +228,13 @@ pub enum IssueCommand {
         #[arg(long)]
         cycle: Option<String>,
 
-        /// New due date (YYYY-MM-DD, or relative like 3d, 1w counting forward from today)
+        /// New due date (YYYY-MM-DD, or relative like 0d, 3d, 1w counting forward from today; 1m is 30 days)
         #[arg(long, alias = "due")]
         due_date: Option<String>,
+
+        /// Remove the issue's due date
+        #[arg(long, conflicts_with = "due_date")]
+        clear_due_date: bool,
 
         /// Attach a file to the issue
         #[arg(long)]
@@ -1774,6 +1778,39 @@ mod tests {
             }
             _ => panic!("expected Issue Edit"),
         }
+    }
+
+    #[test]
+    fn issue_edit_clear_due_date() {
+        let cli = parse(&["lin", "issue", "edit", "APP-1419", "--clear-due-date"]);
+        match cli.command {
+            Commands::Issue(IssueCommand::Edit {
+                due_date,
+                clear_due_date,
+                ..
+            }) => {
+                assert!(clear_due_date);
+                assert_eq!(due_date, None);
+            }
+            _ => panic!("expected Issue Edit"),
+        }
+    }
+
+    #[test]
+    fn issue_edit_due_date_and_clear_conflict() {
+        let result = Cli::try_parse_from([
+            "lin",
+            "issue",
+            "edit",
+            "APP-1419",
+            "--due-date",
+            "2026-09-30",
+            "--clear-due-date",
+        ]);
+        assert!(
+            result.is_err(),
+            "setting and clearing at once must be rejected"
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -171,6 +171,10 @@ pub enum IssueCommand {
         #[arg(long)]
         cycle: Option<String>,
 
+        /// Due date (YYYY-MM-DD, or relative like 3d, 1w counting forward from today)
+        #[arg(long, alias = "due")]
+        due_date: Option<String>,
+
         /// Attach a file to the created issue
         #[arg(long)]
         attachment: Option<String>,
@@ -223,6 +227,10 @@ pub enum IssueCommand {
         /// Cycle (name, number, or "current"; requires --team)
         #[arg(long)]
         cycle: Option<String>,
+
+        /// New due date (YYYY-MM-DD, or relative like 3d, 1w counting forward from today)
+        #[arg(long, alias = "due")]
+        due_date: Option<String>,
 
         /// Attach a file to the issue
         #[arg(long)]
@@ -1713,6 +1721,56 @@ mod tests {
         match cli.command {
             Commands::Issue(IssueCommand::Edit { cycle, .. }) => {
                 assert_eq!(cycle.as_deref(), Some("42"));
+            }
+            _ => panic!("expected Issue Edit"),
+        }
+    }
+
+    #[test]
+    fn issue_create_with_due_date() {
+        let cli = parse(&[
+            "lin",
+            "issue",
+            "create",
+            "Test issue",
+            "--team",
+            "eng",
+            "--due-date",
+            "2026-09-30",
+        ]);
+        match cli.command {
+            Commands::Issue(IssueCommand::Create { due_date, .. }) => {
+                assert_eq!(due_date.as_deref(), Some("2026-09-30"));
+            }
+            _ => panic!("expected Issue Create"),
+        }
+    }
+
+    #[test]
+    fn issue_edit_with_due_date() {
+        let cli = parse(&[
+            "lin",
+            "issue",
+            "edit",
+            "APP-1419",
+            "--due-date",
+            "2026-09-30",
+        ]);
+        match cli.command {
+            Commands::Issue(IssueCommand::Edit { id, due_date, .. }) => {
+                assert_eq!(id, "APP-1419");
+                assert_eq!(due_date.as_deref(), Some("2026-09-30"));
+            }
+            _ => panic!("expected Issue Edit"),
+        }
+    }
+
+    #[test]
+    fn issue_edit_due_alias() {
+        let cli = parse(&["lin", "issue", "edit", "APP-1419", "--due", "1w"]);
+        match cli.command {
+            Commands::Issue(IssueCommand::Edit { due_date, .. }) => {
+                assert_eq!(due_date.as_deref(), Some("1w"));
             }
             _ => panic!("expected Issue Edit"),
         }

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -148,6 +148,7 @@ pub async fn create(
     labels: Option<&[String]>,
     parent: Option<&str>,
     cycle: Option<&str>,
+    due_date: Option<&str>,
     attachment_path: Option<&str>,
 ) -> Result<()> {
     let team_id = resolve::resolve_team_identifier(client, team).await?;
@@ -187,6 +188,10 @@ pub async fn create(
     // Resolve cycle
     if let Some(cyc) = cycle {
         input.cycle_id = Some(resolve::resolve_cycle_identifier(client, &team_id, cyc).await?);
+    }
+
+    if let Some(due) = due_date {
+        input.due_date = Some(date::parse_future_date_only(due)?);
     }
 
     let data: IssueCreateData = client
@@ -233,6 +238,7 @@ pub async fn edit(
     remove_labels: Option<Vec<String>>,
     parent: Option<String>,
     cycle: Option<String>,
+    due_date: Option<String>,
     attachment_path: Option<String>,
 ) -> Result<()> {
     // Resolve label names — fetch issue if labels or cycle need it
@@ -318,6 +324,11 @@ pub async fn edit(
         None => None,
     };
 
+    let resolved_due_date = match due_date {
+        Some(ref d) => Some(date::parse_future_date_only(d)?),
+        None => None,
+    };
+
     let input = IssueUpdateInput {
         title,
         description,
@@ -328,6 +339,7 @@ pub async fn edit(
         label_ids: final_label_ids,
         parent_id: resolved_parent,
         cycle_id: resolved_cycle,
+        due_date: resolved_due_date,
     };
 
     let data: IssueUpdateData = client

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -239,6 +239,7 @@ pub async fn edit(
     parent: Option<String>,
     cycle: Option<String>,
     due_date: Option<String>,
+    clear_due_date: bool,
     attachment_path: Option<String>,
 ) -> Result<()> {
     // Resolve label names — fetch issue if labels or cycle need it
@@ -324,9 +325,11 @@ pub async fn edit(
         None => None,
     };
 
-    let resolved_due_date = match due_date {
-        Some(ref d) => Some(date::parse_future_date_only(d)?),
-        None => None,
+    // Clap rejects --due-date with --clear-due-date, so at most one arm applies.
+    let resolved_due_date = match (due_date.as_ref(), clear_due_date) {
+        (Some(d), _) => Some(json!(date::parse_future_date_only(d)?)),
+        (None, true) => Some(serde_json::Value::Null),
+        (None, false) => None,
     };
 
     let input = IssueUpdateInput {

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,5 +1,25 @@
+use std::sync::OnceLock;
+
 use anyhow::{Result, bail};
-use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
+use time::{Duration, OffsetDateTime, UtcOffset, format_description::well_known::Rfc3339};
+
+static LOCAL_OFFSET: OnceLock<UtcOffset> = OnceLock::new();
+
+/// Captures the system's UTC offset for the rest of the process.
+///
+/// Must be called from `main` *before* the async runtime starts: `time`
+/// refuses to read the system timezone once the process is multi-threaded, so
+/// calling this later silently falls back to UTC. Falls back to UTC if the
+/// offset is unavailable (e.g. no timezone configured).
+pub fn init_local_offset() {
+    let _ = LOCAL_OFFSET.set(UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC));
+}
+
+/// Now, in the offset captured by [`init_local_offset`] (UTC if uninitialized).
+fn now_local() -> OffsetDateTime {
+    let offset = LOCAL_OFFSET.get().copied().unwrap_or(UtcOffset::UTC);
+    OffsetDateTime::now_utc().to_offset(offset)
+}
 
 /// Parses a date string into an ISO 8601 formatted string for the Linear API.
 ///
@@ -81,19 +101,73 @@ pub fn parse_date_only(input: &str) -> Result<String> {
 
 /// Parses a *deadline* date string and returns it as YYYY-MM-DD (TimelessDate).
 ///
-/// Same inputs as [`parse_date_only`], except relative shorthand counts
-/// **forward** from now: `1w` is a week from today, not a week ago. Use this
-/// for fields that name a future date (e.g. issue `dueDate`); use
-/// [`parse_date_only`] for fields that record something already past.
+/// Same inputs as [`parse_date_only`], with three differences, all because a
+/// deadline names a calendar day the user is looking forward to rather than a
+/// timestamp in the past:
+/// - relative shorthand counts **forward**: `1w` is a week from today
+/// - it counts from the *local* day (see [`init_local_offset`]), so `1d` is
+///   tomorrow by the user's calendar, not by UTC's
+/// - zero is valid: `0d` means today
+///
+/// Note `1m` is 30 days, not a calendar month — inherited from the shorthand
+/// the list filters use. Durations that overflow the representable range are
+/// an error, not a panic.
 pub fn parse_future_date_only(input: &str) -> Result<String> {
     let input = input.trim();
 
-    if let Some(duration) = parse_relative(input) {
-        let target = OffsetDateTime::now_utc() + duration;
-        return Ok(target.format(&Rfc3339)?[..10].to_string());
+    match parse_relative_forward(input)? {
+        Some(duration) => {
+            let target = now_local().checked_add(duration).ok_or_else(|| {
+                anyhow::anyhow!("Due date '{}' is too far in the future to represent", input)
+            })?;
+            Ok(target.format(&Rfc3339)?[..10].to_string())
+        }
+        // Not relative shorthand at all — try the absolute formats.
+        None => parse_date_only(input),
+    }
+}
+
+/// Relative shorthand for a deadline: like [`parse_relative`], but accepts a
+/// zero count (`0d` = today) and reports overflow as an error rather than
+/// panicking the way `Duration::weeks` does.
+///
+/// `Ok(None)` means "not relative shorthand, try another format"; `Err` means
+/// "recognizably shorthand, but out of range" — the caller must not retry
+/// those through [`parse_date_only`], which would hit the panic.
+fn parse_relative_forward(input: &str) -> Result<Option<Duration>> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(None);
     }
 
-    parse_date_only(input)
+    let (num_str, unit) = input.split_at(input.len() - 1);
+    if !matches!(unit, "h" | "d" | "w" | "m") {
+        return Ok(None);
+    }
+    let Ok(num) = num_str.parse::<i64>() else {
+        return Ok(None);
+    };
+
+    if num < 0 {
+        bail!(
+            "Due date '{}' is negative; a due date must not be in the past",
+            input
+        );
+    }
+
+    let seconds_per_unit = match unit {
+        "h" => 3_600,
+        "d" => 86_400,
+        "w" => 604_800,
+        "m" => 30 * 86_400, // Approximate month, matching the shorthand elsewhere
+        _ => unreachable!("unit checked above"),
+    };
+
+    let seconds = num
+        .checked_mul(seconds_per_unit)
+        .ok_or_else(|| anyhow::anyhow!("Due date '{}' is too far in the future", input))?;
+
+    Ok(Some(Duration::seconds(seconds)))
 }
 
 /// Adds a relative duration (e.g., "1w", "10d") to an ISO 8601 date string.
@@ -256,5 +330,32 @@ mod tests {
     #[test]
     fn future_date_only_invalid() {
         assert!(parse_future_date_only("not-a-date").is_err());
+    }
+
+    #[test]
+    fn future_date_only_zero_is_today() {
+        let today = now_local().format(&Rfc3339).unwrap()[..10].to_string();
+        assert_eq!(parse_future_date_only("0d").unwrap(), today);
+        assert_eq!(parse_future_date_only("0w").unwrap(), today);
+    }
+
+    #[test]
+    fn future_date_only_rejects_negative() {
+        assert!(parse_future_date_only("-1w").is_err());
+    }
+
+    #[test]
+    fn future_date_only_overflow_errors_not_panics() {
+        // `parse_date` panics on these; the deadline path must not.
+        assert!(parse_future_date_only("9999999999w").is_err());
+        assert!(parse_future_date_only("100000000000000w").is_err());
+    }
+
+    #[test]
+    fn future_date_only_counts_from_local_day() {
+        // Whatever offset was captured, the anchor is that day — not UTC's,
+        // unless they happen to coincide.
+        let local_today = now_local().format(&Rfc3339).unwrap()[..10].to_string();
+        assert_eq!(parse_future_date_only("0d").unwrap(), local_today);
     }
 }

--- a/src/date.rs
+++ b/src/date.rs
@@ -79,6 +79,23 @@ pub fn parse_date_only(input: &str) -> Result<String> {
     Ok(full[..10].to_string())
 }
 
+/// Parses a *deadline* date string and returns it as YYYY-MM-DD (TimelessDate).
+///
+/// Same inputs as [`parse_date_only`], except relative shorthand counts
+/// **forward** from now: `1w` is a week from today, not a week ago. Use this
+/// for fields that name a future date (e.g. issue `dueDate`); use
+/// [`parse_date_only`] for fields that record something already past.
+pub fn parse_future_date_only(input: &str) -> Result<String> {
+    let input = input.trim();
+
+    if let Some(duration) = parse_relative(input) {
+        let target = OffsetDateTime::now_utc() + duration;
+        return Ok(target.format(&Rfc3339)?[..10].to_string());
+    }
+
+    parse_date_only(input)
+}
+
 /// Adds a relative duration (e.g., "1w", "10d") to an ISO 8601 date string.
 pub fn add_duration_to_date(date_str: &str, duration_str: &str) -> Result<String> {
     let duration = parse_relative(duration_str).ok_or_else(|| {
@@ -220,5 +237,24 @@ mod tests {
     #[test]
     fn parse_date_only_invalid() {
         assert!(parse_date_only("not-a-date").is_err());
+    }
+
+    #[test]
+    fn future_date_only_iso_is_verbatim() {
+        assert_eq!(parse_future_date_only("2026-09-30").unwrap(), "2026-09-30");
+    }
+
+    #[test]
+    fn future_date_only_relative_counts_forward() {
+        let today = OffsetDateTime::now_utc().format(&Rfc3339).unwrap()[..10].to_string();
+        let future = parse_future_date_only("1w").unwrap();
+        let past = parse_date_only("1w").unwrap();
+        assert!(future > today, "{} should be after {}", future, today);
+        assert!(past < today, "{} should be before {}", past, today);
+    }
+
+    #[test]
+    fn future_date_only_invalid() {
+        assert!(parse_future_date_only("not-a-date").is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,7 @@ async fn run(cli: Cli) -> Result<()> {
                     labels,
                     parent,
                     cycle,
+                    due_date,
                     attachment,
                 } => {
                     commands::issue::create(
@@ -100,6 +101,7 @@ async fn run(cli: Cli) -> Result<()> {
                         labels.as_deref(),
                         parent.as_deref(),
                         cycle.as_deref(),
+                        due_date.as_deref(),
                         attachment.as_deref(),
                     )
                     .await?;
@@ -117,6 +119,7 @@ async fn run(cli: Cli) -> Result<()> {
                     remove_labels,
                     parent,
                     cycle,
+                    due_date,
                     attachment,
                     comment,
                 } => {
@@ -134,6 +137,7 @@ async fn run(cli: Cli) -> Result<()> {
                         remove_labels,
                         parent,
                         cycle,
+                        due_date,
                         attachment,
                     )
                     .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,15 @@ fn ensure_auth(cli_workspace: Option<&str>, json: bool, verbose: bool) -> Result
     })
 }
 
+fn main() {
+    // Must happen while the process is still single-threaded — the `time`
+    // crate will not read the system timezone once tokio has spawned workers.
+    date::init_local_offset();
+    tokio_main();
+}
+
 #[tokio::main]
-async fn main() {
+async fn tokio_main() {
     let cli = Cli::parse();
 
     if let Err(e) = run(cli).await {
@@ -120,6 +127,7 @@ async fn run(cli: Cli) -> Result<()> {
                     parent,
                     cycle,
                     due_date,
+                    clear_due_date,
                     attachment,
                     comment,
                 } => {
@@ -138,6 +146,7 @@ async fn run(cli: Cli) -> Result<()> {
                         parent,
                         cycle,
                         due_date,
+                        clear_due_date,
                         attachment,
                     )
                     .await?;


### PR DESCRIPTION
Closes #49.

Linear's `dueDate` was readable from the CLI (`issue view` prints it, `issue list --due-after`/`--due-before` filter on it) but not settable — setting a deadline meant the web UI or a hand-rolled `lin gql` mutation.

Adds `--due-date` (alias `--due`) to `issue create` and `issue edit`, plus `--clear-due-date` on `issue edit`, following the `--start`/`--target` flags on `project create`/`project edit` from #40.

```sh
lin issue create "Ship v2" --team APP --due-date 2026-09-30
lin issue edit APP-1419 --due-date 2026-09-30
lin issue edit APP-1419 --due 1w              # one week from today
lin issue edit APP-1419 --due 0d              # today
lin issue edit APP-1419 --clear-due-date
```

### Why a new date helper

`date::parse_date` resolves relative shorthand into the past (`now - duration`). That is right for the filters it was written for — `--due-after 3d` means "due after three days ago" — and wrong for a deadline, where `--due 1w` should mean a week from today.

Rather than change `parse_date` and shift the meaning of the existing filters, this adds `date::parse_future_date_only`, which counts forward, accepts a zero count (`0d` = today), and errors rather than panicking when a duration overflows.

### Local dates, and why `main` changed

Relative due dates count from the **local** day. `dueDate` is a `TimelessDate`, so anchoring to UTC put the date a day off for anyone far enough from UTC — at UTC+14 it is already Aug 11 when UTC says Aug 10.

`time` will not read the system timezone once the process is multi-threaded, so the offset has to be captured before tokio starts. `main` is now a sync wrapper that calls `date::init_local_offset()` and then enters the async entry point. It falls back to UTC if the offset is unavailable.

Verified against the built binary at 14:13 UTC on 2026-08-10:

| TZ | captured offset | `--due 0d` |
|---|---|---|
| `UTC` | +00:00 | 2026-08-10 |
| `America/Los_Angeles` | -07:00 | 2026-08-10 |
| `Pacific/Kiritimati` | +14:00 | 2026-08-11 |

### Clearing

`--clear-due-date` sends an explicit `null`; `IssueUpdateInput.due_date` is a `serde_json::Value` so `None` still omits the field. It is an explicit flag rather than `--due-date ""` because an empty string is what an unset shell variable expands to, and `--due-date "$MY_DATE"` should not silently wipe the date. Clap rejects the two flags together.

### Known limits

`1m` means 30 days, not a calendar month, and `1y` is unsupported — both inherited from the shorthand the list filters use, and now stated in `--help`.

Large relative durations still panic in `parse_date` itself, which affects the pre-existing `--due-after`, `project --target`, and `cycle --starts` flags. Not a regression from this PR and not fixed here — filed as #51.

### Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all pass — 104 tests, 12 new. Help text, the flag conflict, and the timezone table above were all checked against the built binary.

Note: built and tested against Rust 1.95.0, not the 1.93.1 pinned in `rust-toolchain.toml` — the pinned toolchain could not be installed in my environment. CI will cover the pinned version.