### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-10
+
 ### Added
 - `issue relate <id> --to <id>` command to link two issues via Linear's `issueRelationCreate` mutation, with `--type blocks|blocked-by|related|duplicate` (default `related`); `blocked-by` is sugar for a `blocks` relation with the issues swapped
 - `issue relations <id>` command to list an issue's outgoing and incoming relations (including the relation IDs needed to remove them)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "lin-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lin-cli"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.93.1"
 description = "A fast CLI for Linear"


### PR DESCRIPTION
Release prep for v0.8.0.

- `Cargo.toml` / `Cargo.lock` version -> 0.8.0
- `CHANGELOG.md`: `[Unreleased]` contents moved under `## [0.8.0] - 2026-08-10`, empty `[Unreleased]` retained

Covers #48 (issue relations, raw GraphQL, label edit/delete) and #50 (issue due dates). Minor bump: all additions are backwards compatible.

Tagging `v0.8.0` after this merges triggers the release workflow — artifacts, GitHub release, `cargo publish`, Homebrew formula.