### PR TITLE
fix: restore Linux build target in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
       - "Cargo.lock"
       - "CHANGELOG.md"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/release.yml"
       - "rust-toolchain.toml"
       - "justfile"
   merge_group:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
           - runner: macos-latest
             target: x86_64-apple-darwin
             asset: lin-macos-x86_64.tar.gz
-          - runner: ubuntu-22.04
-            target: blacksmith-4vcpu-ubuntu-2404
+          - runner: blacksmith-4vcpu-ubuntu-2404
+            target: x86_64-unknown-linux-gnu
             asset: lin-linux-x86_64.tar.gz
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `--label` flag now finds all workspace labels by paginating through the Linear API instead of only checking the first page
 - `cycle show`, `issue list`, `initiative list`, and `changelog` no longer panic when a title contains a multi-byte UTF-8 character (e.g. em dash) at the truncation boundary
+- Release workflow built the Linux artifact for a target named after the Blacksmith runner label instead of `x86_64-unknown-linux-gnu`, which failed the build and skipped the release, crates.io publish, and Homebrew steps (#44 regression, fixed in #53)
 
 ### Changed
 - CI: migrate GitHub Actions workflows to Blacksmith runners for faster builds and shared caching (#44)
+- CI now also runs on changes to `.github/workflows/release.yml`, so a release-workflow-only PR can satisfy the required status checks
 
 ## [0.7.0] - 2026-04-01
 


### PR DESCRIPTION
The v0.8.0 tag failed to release. The Linux build job errored:

```
error: toolchain '1.93.1-x86_64-unknown-linux-gnu' does not support target 'blacksmith-4vcpu-ubuntu-2404'
```

`fail-fast` then cancelled both macOS builds, and `Release`, `Publish to crates.io`, and `Update Homebrew formula` were skipped. Nothing was published — crates.io is still on 0.7.0 and no `v0.8.0` release exists.

## Cause

#44 replaced the runner label everywhere it appeared in the workflows, including the build matrix's `target:` field:

```diff
-            target: x86_64-unknown-linux-gnu
+            target: blacksmith-4vcpu-ubuntu-2404
```

That left the Linux entry with the Blacksmith label as its *build target* and `ubuntu-22.04` as its runner — the two fields swapped in effect. CI (`ci.yml`) was unaffected because it has no target matrix, so this stayed invisible until the first tag after the migration.

## Fix

```diff
-          - runner: ubuntu-22.04
-            target: blacksmith-4vcpu-ubuntu-2404
+          - runner: blacksmith-4vcpu-ubuntu-2404
+            target: x86_64-unknown-linux-gnu
```

The macOS entries are untouched — they were cancelled by fail-fast, not failing on their own.

Once this merges, `v0.8.0` needs to be re-tagged onto the new HEAD: the tag push is what triggers the workflow, and the workflow file is read from the tagged commit, so the current tag would replay the same failure.